### PR TITLE
Fix for getFileName() method when file name does not have an extension.

### DIFF
--- a/Excel.php
+++ b/Excel.php
@@ -565,9 +565,9 @@ class Excel extends Widget
                     $firstCol = $col;
                 }
                 if (is_array($column)) {
-                    $column_value = $this->executeGetColumnData($model, $column);
+                    $column_value = $this->executeGetColumnData($model, $row, $column);
                 } else {
-                    $column_value = $this->executeGetColumnData($model, ['attribute' => $column]);
+                    $column_value = $this->executeGetColumnData($model, $row, ['attribute' => $column]);
                 }
                 if (isset($column['format'])) {
                     $formatOptions = [];
@@ -681,14 +681,14 @@ class Excel extends Widget
     }
 
     /**
-     * Getting column value. 
+     * Getting column value.
      *
      * @param $model
+     * @param int $row
      * @param array $params
      * @return bool|float|mixed|string|null
-     * @throws \Exception
      */
-    public function executeGetColumnData($model, $params = [])
+    public function executeGetColumnData($model,int $row ,array $params = [])
     {
         $value = null;
         try {
@@ -696,7 +696,7 @@ class Excel extends Widget
                 if (is_string($params['value'])) {
                     $value = ArrayHelper::getValue($model, $params['value']);
                 } else {
-                    $value = call_user_func($params['value'], $model, $this);
+                    $value = call_user_func($params['value'], $model, $this, $row);
                 }
             } elseif (isset($params['attribute']) && $params['attribute'] !== null) {
                 $value = ArrayHelper::getValue($model, $params['attribute']);

--- a/Excel.php
+++ b/Excel.php
@@ -883,8 +883,6 @@ class Excel extends Widget
             $path = $this->savePath . '/' . $this->getFileName();
         }
         $objectWriter->save($path);
-        exit;
-
     }
 
     /**

--- a/Excel.php
+++ b/Excel.php
@@ -378,6 +378,9 @@ class Excel extends Widget
     /** @var array array[] */
     public $titleRows = [];
 
+    /** @var array array[] */
+    public $footerRows = [];
+
     /** @var array  */
     public $loadDataInExcelStyle = [];
 
@@ -415,12 +418,17 @@ class Excel extends Widget
         return $this->titleStartRow;
     }
 
-    public function getTableStartRow(): int
+    public function getStartRow(): int
     {
         if ($this->tableStartRow === null) {
             $this->tableStartRow = $this->_lastRow + 1;
         }
         return $this->tableStartRow;
+    }
+
+    public function getNextRow(): int
+    {
+        return $this->_lastRow + 1;
     }
 
     /**
@@ -447,7 +455,7 @@ class Excel extends Widget
             }
         }
         $hasHeader = false;
-        $row = $this->getTableStartRow();
+        $row = $this->getStartRow();
         $char = 26;
         while( ( $model = array_shift( $models ) ) !== null ){
             if (empty($columns)) {
@@ -938,8 +946,9 @@ class Excel extends Widget
             } else {
                 $worksheet = $sheet->getActiveSheet();
                 $this->setPageSettings($worksheet);
-                $this->_lastRow = $this->writeTitleRows($this->titleRows, 1, $this->getTitleStartRow(), $worksheet);
+                $this->_lastRow = $this->writeRows($this->titleRows, 1, $this->getTitleStartRow(), $worksheet);
                 $this->executeColumns($this->models, isset($this->columns) ? $this->populateColumns($this->columns) : [], $this->headers ?? [], $worksheet);
+                $this->_lastRow = $this->writeRows($this->footerRows, 1, $this->getNextRow(), $worksheet);
             }
 
             if ($this->asAttachment) {
@@ -970,12 +979,13 @@ class Excel extends Widget
      * @return int last title row
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    public function writeTitleRows(array $rows, int $x, int $y, &$activeSheet): int
+    public function writeRows(array $rows, int $x, int $y, &$activeSheet): int
     {
         if (!$rows) {
             return 0;
         }
         $lde = new LoadDataInExcel($activeSheet, $x, $y);
+        $lde->tn->y = $y;
         $lde->classStyle = $this->loadDataInExcelStyle;
         foreach ($rows as $row) {
             $lde->fillRow($row);

--- a/Excel.php
+++ b/Excel.php
@@ -2,7 +2,6 @@
 
 namespace moonland\phpexcel;
 
-use arogachev\excel\helpers\PHPExcelHelper;
 use DateTime;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -345,10 +344,11 @@ class Excel extends Widget
     public $headerStyle = [
         'font' => [
             'bold' => true,
-            'color' => array('rgb' => 'FFFDFE' )
+            'color' => ['rgb' => 'FFFDFE' ]
         ],
         'alignment' => [
             'horizontal' => Alignment::HORIZONTAL_CENTER,
+            'vertical' => Alignment::VERTICAL_JUSTIFY
         ],
         'borders' => [
             'top' => [
@@ -360,6 +360,9 @@ class Excel extends Widget
             'color' => ['rgb' => '7ebf00' ]
         ],
     ];
+
+    /** @var int */
+    public $headerHeight;
 
     public $bodyStyle = [
         'borders' => [
@@ -531,10 +534,13 @@ class Excel extends Widget
                         ->applyFromArray($column['headerStyle']);
                 }
                 if ($this->freezeHeader) {
-                    $activeSheet->freezePaneByColumnAndRow(1, 2);
+                    $activeSheet->freezePaneByColumnAndRow(1, $row + 1);
                 }
                 if ($this->autoFilter) {
                     $activeSheet->setAutoFilter('A' . $row . ':' . $col . $row);
+                }
+                if($this->headerHeight){
+                    $activeSheet->getRowDimension($row)->setRowHeight($this->headerHeight);
                 }
                 $hasHeader = true;
                 $row++;
@@ -579,7 +585,7 @@ class Excel extends Widget
                                 ->setFormatCode($this->dateFormat);
                             break;
                         case 'text':
-                            if (is_string($column_value) && $column_value[0] === '0') {
+                            if (is_string($column_value) && strpos($column_value, '0') === 0) {
                                 $activeSheet
                                     ->getCell($col . $row)
                                     ->setValueExplicit($column_value, DataType::TYPE_STRING);

--- a/Excel.php
+++ b/Excel.php
@@ -533,12 +533,34 @@ class Excel extends \yii\base\Widget
 	 */
 	public function getFileName()
 	{
-		$fileName = 'exports.xls';
 		if (isset($this->fileName)) {
 			$fileName = $this->fileName;
-			if (strpos($fileName, '.xls') === false)
-				$fileName .= '.xls';
+		} else {
+			$fileName = 'exports';
 		}
+
+		$pathinfo = pathinfo($this->fileName);
+		if (!isset($pathinfo['extension'])) {
+			$extensionMap = [
+				'Excel2007' => '.xlsx',
+				'Excel5' => '.xls',
+				'Excel2003XML' => '.xml',
+				'OOCalc' => '.ods',
+				'SYLK' => '.slk',
+				'Gnumeric' => '.Gnumeric',
+				'HTML' => '.html',
+				'CSV' => '.csv',
+			];
+
+			if(isset($this->format)) {
+				if(isset($extensionMap[$format])) {
+					$fileName .= $extensionMap[$this->format];
+				}
+			} else {
+				$fileName .= $extensionMap['Excel2007'];
+			}
+		}
+
 		return $fileName;
 	}
 	

--- a/Excel.php
+++ b/Excel.php
@@ -324,16 +324,15 @@ class Excel extends \yii\base\Widget
     /**
      * Setting data from models
      */
-    public function executeColumns(&$activeSheet = null, $models, $columns = [], $headers = [])
+    public function executeColumns(&$activeSheet = null, &$models, $columns = [], $headers = [])
     {
-        if ($activeSheet == null) {
+        if ($activeSheet === null) {
             $activeSheet = $this->activeSheet;
         }
         $hasHeader = false;
         $row = 1;
         $char = 26;
         while( ( $model = array_pop( $models ) ) !== null ){
-//        foreach ($models as $model) {
             if (empty($columns)) {
                 $columns = $model->attributes();
             }
@@ -344,7 +343,7 @@ class Excel extends \yii\base\Widget
                 foreach ($columns as $key => $column) {
                     $col = '';
                     if ($colnum > $char) {
-                        $colplus += 1;
+                        $colplus ++;
                         $colnum = 1;
                         $isPlus = true;
                     }
@@ -581,13 +580,13 @@ class Excel extends \yii\base\Widget
     /**
      * saving the xls file to download or to path
      */
-    public function writeFile($sheet)
+    public function writeFile(&$sheet)
     {
         if (!isset($this->format)) {
             $this->format = 'Xlsx';
         }
         $objectwriter = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($sheet, $this->format);
-        unset($sheet);
+        $sheet = null;
         $path = 'php://output';
         if (isset($this->savePath) && $this->savePath !== null) {
             $path = $this->savePath . '/' . $this->getFileName();

--- a/Excel.php
+++ b/Excel.php
@@ -110,6 +110,12 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
  *            [
  *                    'attribute' => 'content',
  *                    'header' => 'Content Post',
+ *                    'headerStyle' => [
+ *                        'font' => [
+ *                          'bold' => true,
+ *                          'color' => array('rgb' => 'FFFDFE' )
+ *                        ],
+ *                     ],
  *                    'format' => 'text',
  *                    'autoSize' => true,
  *                    'value' => function($model) {
@@ -468,6 +474,7 @@ class Excel extends Widget
                 $colplus = 0;
                 $colnum = 1;
                 $col = '';
+                $headerStyleColums = [];
                 foreach ($columns as $key => $column) {
                     $col = '';
                     if ($colnum > $char) {
@@ -480,6 +487,12 @@ class Excel extends Widget
                     }
                     $col .= chr(64 + $colnum);
                     $header = '';
+                    if(isset($column['headerStyle'])){
+                        $headerStyleColums[] = [
+                            'headerStyle' => $column['headerStyle'],
+                            'colrow' => $col.$row
+                        ];
+                    }
                     if (is_array($column)) {
                         if (isset($column['header'])) {
                             $header = $column['header'];
@@ -511,6 +524,11 @@ class Excel extends Widget
                     $activeSheet
                         ->getStyle('A' . $row . ':' . $col . $row)
                         ->applyFromArray($this->headerStyle);
+                }
+                foreach ($headerStyleColums as $column) {
+                    $activeSheet
+                        ->getStyle($column['colrow'])
+                        ->applyFromArray($column['headerStyle']);
                 }
                 if ($this->freezeHeader) {
                     $activeSheet->freezePaneByColumnAndRow(1, 2);

--- a/Excel.php
+++ b/Excel.php
@@ -883,6 +883,9 @@ class Excel extends Widget
             $path = $this->savePath . '/' . $this->getFileName();
         }
         $objectWriter->save($path);
+        if ($this->asAttachment) {
+            exit();
+        }
     }
 
     /**

--- a/Excel.php
+++ b/Excel.php
@@ -20,6 +20,7 @@ use yii\base\Widget;
 use yii\helpers\ArrayHelper;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidArgumentException;
+use yii\helpers\VarDumper;
 use yii\i18n\Formatter;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
@@ -724,6 +725,9 @@ class Excel extends Widget
                     return $value;
                 }
                 if ($params['format'] === 'date' || ($params['format'][0] ?? '') === 'date') {
+                    if($value === '0000-00-00'){
+                        $value = '';
+                    }
                     /**
                      * if date without time, add 00:00:00 as time
                      */
@@ -741,6 +745,16 @@ class Excel extends Widget
             }
         }catch (\Exception $exception) {
             Yii::error('Exception:' . $exception->getMessage());
+            if(is_object($model)) {
+                Yii::error('$model: ' . VarDumper::dumpAsString($model->attributes));
+            }else{
+                Yii::error('$model: ' . VarDumper::dumpAsString($model));
+            }
+            Yii::error('$row: ' . $row);
+            if($params){
+                Yii::error('$params: ' . VarDumper::dumpAsString($params));
+            }
+            Yii::error($exception->getTraceAsString());
             return '???';
         }
         return $value;

--- a/Excel.php
+++ b/Excel.php
@@ -594,29 +594,33 @@ class Excel extends Widget
     public function executeGetColumnData($model, $params = [])
     {
         $value = null;
-        if (isset($params['value']) && $params['value'] !== null) {
-            if (is_string($params['value'])) {
-                $value = ArrayHelper::getValue($model, $params['value']);
-            } else {
-                $value = call_user_func($params['value'], $model, $this);
-            }
-        } elseif (isset($params['attribute']) && $params['attribute'] !== null) {
-            $value = ArrayHelper::getValue($model, $params['attribute']);
-        }
-
-        if (isset($params['format'])){
-
-            if($params['format'] === 'date' || ($params['format'][0]??'') === 'date'){
-                if(!$dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $value . ' 00:00:00', new DateTimeZone('UTC'))){
-                    return $value;
+        try {
+            if (isset($params['value']) && $params['value'] !== null) {
+                if (is_string($params['value'])) {
+                    $value = ArrayHelper::getValue($model, $params['value']);
+                } else {
+                    $value = call_user_func($params['value'], $model, $this);
                 }
-                return Date::PHPToExcel($dateTime->getTimestamp());
+            } elseif (isset($params['attribute']) && $params['attribute'] !== null) {
+                $value = ArrayHelper::getValue($model, $params['attribute']);
             }
-            if($params['format'] !== null){
-                return $this->formatter()->format($value, $params['format']);
-            }
-        }
 
+            if (isset($params['format'])) {
+
+                if ($params['format'] === 'date' || ($params['format'][0] ?? '') === 'date') {
+                    if (!$dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $value . ' 00:00:00', new DateTimeZone('UTC'))) {
+                        return $value;
+                    }
+                    return Date::PHPToExcel($dateTime->getTimestamp());
+                }
+                if ($params['format'] !== null) {
+                    return $this->formatter()->format($value, $params['format']);
+                }
+            }
+        }catch (\Exception $exception){
+            Yii::error('Exception:' . $exception->getMessage());
+            return '???';
+        }
         return $value;
     }
 

--- a/Excel.php
+++ b/Excel.php
@@ -698,6 +698,12 @@ class Excel extends Widget
                 } else {
                     $value = call_user_func($params['value'], $model, $this, $row);
                 }
+            } elseif (isset($params['list']) && is_array($params['list'])) {
+                if($value = ArrayHelper::getValue($model, $params['attribute'])) {
+                    $value = $params['list'][$value] ?? $value . '!';
+                }else{
+                    $value = '';
+                }
             } elseif (isset($params['attribute']) && $params['attribute'] !== null) {
                 $value = ArrayHelper::getValue($model, $params['attribute']);
             }

--- a/Excel.php
+++ b/Excel.php
@@ -332,7 +332,8 @@ class Excel extends \yii\base\Widget
         $hasHeader = false;
         $row = 1;
         $char = 26;
-        foreach ($models as $model) {
+        while( ( $model = array_pop( $models ) ) !== null ){
+//        foreach ($models as $model) {
             if (empty($columns)) {
                 $columns = $model->attributes();
             }
@@ -586,12 +587,14 @@ class Excel extends \yii\base\Widget
             $this->format = 'Xlsx';
         }
         $objectwriter = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($sheet, $this->format);
+        unset($sheet);
         $path = 'php://output';
         if (isset($this->savePath) && $this->savePath !== null) {
             $path = $this->savePath . '/' . $this->getFileName();
         }
         $objectwriter->save($path);
-        exit();
+        exit;
+
     }
 
     /**
@@ -665,7 +668,7 @@ class Excel extends \yii\base\Widget
      */
     public function run()
     {
-        if ($this->mode == self::EXPORT) {
+        if ($this->mode === self::EXPORT) {
             $sheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
 
             if (!isset($this->models))

--- a/Excel.php
+++ b/Excel.php
@@ -335,6 +335,7 @@ class Excel extends Widget
      * @var string format in excel style
      */
     public $dateFormat  = 'dd/mm/yy';
+    public $dateTimeFormat  = 'd/m/yy h:mm';
     /**
      * @var bool freeze header rows
      */
@@ -583,6 +584,15 @@ class Excel extends Widget
                                 ->getStyle($col . $row)
                                 ->getNumberFormat()
                                 ->setFormatCode($this->dateFormat);
+                            break;
+                        case 'date-time':
+                            if($date = DateTime::createFromFormat('Y-m-d H:i:s',$column_value)) {
+                                $column_value = Date::PHPToExcel($date->getTimestamp());
+                                $activeSheet
+                                    ->getStyle($col . $row)
+                                    ->getNumberFormat()
+                                    ->setFormatCode($this->dateTimeFormat);
+                            }
                             break;
                         case 'text':
                             if (is_string($column_value) && strpos($column_value, '0') === 0) {

--- a/Excel.php
+++ b/Excel.php
@@ -378,7 +378,7 @@ class Excel extends \yii\base\Widget
         $hasHeader = false;
         $row = 1;
         $char = 26;
-        while( ( $model = array_pop( $models ) ) !== null ){
+        while( ( $model = array_shift( $models ) ) !== null ){
             if (empty($columns)) {
                 $columns = $model->attributes();
             }

--- a/Excel.php
+++ b/Excel.php
@@ -566,7 +566,7 @@ class Excel extends \yii\base\Widget
 	
 	/**
 	 * Setting properties for excel file
-	 * @param PHPExcel $objectExcel
+	 * @param \PhpOffice\PhpSpreadsheet\Spreadsheet $objectExcel
 	 * @param array $properties
 	 */
 	public function properties(&$objectExcel, $properties = [])
@@ -585,7 +585,7 @@ class Excel extends \yii\base\Widget
 	{
 		if (!isset($this->format))
 			$this->format = 'Excel2007';
-		$objectwriter = \PHPExcel_IOFactory::createWriter($sheet, $this->format);
+		$objectwriter = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($sheet, $this->format);
 		$path = 'php://output';
 		if (isset($this->savePath) && $this->savePath != null) {
 			$path = $this->savePath . '/' . $this->getFileName();
@@ -600,8 +600,8 @@ class Excel extends \yii\base\Widget
 	public function readFile($fileName)
 	{
 		if (!isset($this->format))
-			$this->format = \PHPExcel_IOFactory::identify($fileName);
-		$objectreader = \PHPExcel_IOFactory::createReader($this->format);
+			$this->format = \PhpOffice\PhpSpreadsheet\IOFactory::identify($fileName);
+		$objectreader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($this->format);
 		$objectPhpExcel = $objectreader->load($fileName);
 		
 		$sheetCount = $objectPhpExcel->getSheetCount();
@@ -666,7 +666,7 @@ class Excel extends \yii\base\Widget
 	{
 		if ($this->mode == 'export') 
 		{
-	    	$sheet = new \PHPExcel();
+	    	$sheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
 	    	
 	    	if (!isset($this->models))
 	    		throw new InvalidConfigException('Config models must be set');

--- a/Excel.php
+++ b/Excel.php
@@ -514,13 +514,13 @@ class Excel extends Widget
                     } elseif (!isset($column['autoSize']) || $column['autoSize']) {
                         $activeSheet->getColumnDimension($col)->setAutoSize(true);
                     }
-                    if (isset($column['excelWrap'])) {
+                    //if (isset($column['excelWrap'])) {
                         $activeSheet
                             ->getStyle($col . $row)
                             ->getAlignment()
-                            ->setWrapText($column['excelWrap'])
+                            ->setWrapText(true)
                         ;
-                    }
+                    //}
                     $colnum ++;
                 }
                 if ($this->headerStyle) {

--- a/Excel.php
+++ b/Excel.php
@@ -720,6 +720,9 @@ class Excel extends Widget
             }
 
             if (isset($params['format'])) {
+                if ($params['format'] == 'date-time') {
+                    return $value;
+                }
                 if ($params['format'] === 'date' || ($params['format'][0] ?? '') === 'date') {
                     /**
                      * if date without time, add 00:00:00 as time

--- a/Excel.php
+++ b/Excel.php
@@ -699,7 +699,8 @@ class Excel extends Widget
                     $value = call_user_func($params['value'], $model, $this, $row);
                 }
             } elseif (isset($params['list']) && is_array($params['list'])) {
-                if($value = ArrayHelper::getValue($model, $params['attribute'])) {
+                $value = ArrayHelper::getValue($model, $params['attribute']);
+                if($value !== null && $value !== ''){
                     $value = $params['list'][$value] ?? $value . '!';
                 }else{
                     $value = '';

--- a/Excel.php
+++ b/Excel.php
@@ -4,806 +4,803 @@ namespace moonland\phpexcel;
 
 use yii\helpers\ArrayHelper;
 use yii\base\InvalidConfigException;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\i18n\Formatter;
+
 
 /**
  * Excel Widget for generate Excel File or for load Excel File.
- * 
+ *
  * Usage
  * -----
- * 
+ *
  * Exporting data into an excel file.
- * 
+ *
  * ~~~
- * 
+ *
  * // export data only one worksheet.
- * 
+ *
  * \moonland\phpexcel\Excel::widget([
- * 		'models' => $allModels,
- * 		'mode' => 'export', //default value as 'export'
- * 		'columns' => ['column1','column2','column3'],
- * 		//without header working, because the header will be get label from attribute label.
- * 		'headers' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *        'models' => $allModels,
+ *        'mode' => 'export', //default value as 'export'
+ *        'columns' => ['column1','column2','column3'],
+ *        //without header working, because the header will be get label from attribute label.
+ *        'headers' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
  * ]);
- * 
+ *
  * \moonland\phpexcel\Excel::export([
- * 		'models' => $allModels,
- * 		'columns' => ['column1','column2','column3'],
- * 		//without header working, because the header will be get label from attribute label.
- * 		'headers' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *        'models' => $allModels,
+ *        'columns' => ['column1','column2','column3'],
+ *        //without header working, because the header will be get label from attribute label.
+ *        'headers' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
  * ]);
- * 
+ *
  * // export data with multiple worksheet.
- * 
+ *
  * \moonland\phpexcel\Excel::widget([
- * 		'isMultipleSheet' => true,
- * 		'models' => [
- * 			'sheet1' => $allModels1, 
- * 			'sheet2' => $allModels2, 
- * 			'sheet3' => $allModels3
- * 		],
- * 		'mode' => 'export', //default value as 'export'
- * 		'columns' => [
- * 			'sheet1' => ['column1','column2','column3'],
- * 			'sheet2' => ['column1','column2','column3'],
- * 			'sheet3' => ['column1','column2','column3']
- * 		],
- * 		//without header working, because the header will be get label from attribute label.
- * 		'headers' => [
- * 			'sheet1' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'], 
- * 			'sheet2' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'], 
- * 			'sheet3' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3']
- * 		],
+ *        'isMultipleSheet' => true,
+ *        'models' => [
+ *            'sheet1' => $allModels1,
+ *            'sheet2' => $allModels2,
+ *            'sheet3' => $allModels3
+ *        ],
+ *        'mode' => 'export', //default value as 'export'
+ *        'columns' => [
+ *            'sheet1' => ['column1','column2','column3'],
+ *            'sheet2' => ['column1','column2','column3'],
+ *            'sheet3' => ['column1','column2','column3']
+ *        ],
+ *        //without header working, because the header will be get label from attribute label.
+ *        'headers' => [
+ *            'sheet1' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *            'sheet2' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *            'sheet3' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3']
+ *        ],
  * ]);
- * 
+ *
  * \moonland\phpexcel\Excel::export([
- * 		'isMultipleSheet' => true,
- * 		'models' => [
- * 			'sheet1' => $allModels1, 
- * 			'sheet2' => $allModels2, 
- * 			'sheet3' => $allModels3
- * 		],
- * 		'columns' => [
- * 			'sheet1' => ['column1','column2','column3'],
- * 			'sheet2' => ['column1','column2','column3'],
- * 			'sheet3' => ['column1','column2','column3']
- * 		],
- * 		//without header working, because the header will be get label from attribute label.
- * 		'headers' => [
- * 			'sheet1' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'], 
- * 			'sheet2' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'], 
- * 			'sheet3' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3']
- * 		],
+ *        'isMultipleSheet' => true,
+ *        'models' => [
+ *            'sheet1' => $allModels1,
+ *            'sheet2' => $allModels2,
+ *            'sheet3' => $allModels3
+ *        ],
+ *        'columns' => [
+ *            'sheet1' => ['column1','column2','column3'],
+ *            'sheet2' => ['column1','column2','column3'],
+ *            'sheet3' => ['column1','column2','column3']
+ *        ],
+ *        //without header working, because the header will be get label from attribute label.
+ *        'headers' => [
+ *            'sheet1' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *            'sheet2' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+ *            'sheet3' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3']
+ *        ],
  * ]);
- * 
+ *
  * ~~~
- * 
- * New Feature for exporting data, you can use this if you familiar yii gridview. 
+ *
+ * New Feature for exporting data, you can use this if you familiar yii gridview.
  * That is same with gridview data column.
  * Columns in array mode valid params are 'attribute', 'header', 'format', 'value', and footer (TODO).
  * Columns in string mode valid layout are 'attribute:format:header:footer(TODO)'.
- * 
+ *
  * ~~~
- * 
+ *
  * \moonland\phpexcel\Excel::export([
- *  	'models' => Post::find()->all(),
- *     	'columns' => [
- *     		'author.name:text:Author Name',
- *     		[
- *     				'attribute' => 'content',
- *     				'header' => 'Content Post',
- *     				'format' => 'text',
- *     				'value' => function($model) {
- *     					return ExampleClass::removeText('example', $model->content);
- *     				},
- *     		],
- *     		'like_it:text:Reader like this content',
- *     		'created_at:datetime',
- *     		[
- *     				'attribute' => 'updated_at',
- *     				'format' => 'date',
- *     		],
- *     	],
- *     	'headers' => [
- *     		'created_at' => 'Date Created Content',
- * 		],
+ *    'models' => Post::find()->all(),
+ *        'columns' => [
+ *            'author.name:text:Author Name',
+ *            [
+ *                    'attribute' => 'content',
+ *                    'header' => 'Content Post',
+ *                    'format' => 'text',
+ *                    'value' => function($model) {
+ *                        return ExampleClass::removeText('example', $model->content);
+ *                    },
+ *            ],
+ *            'like_it:text:Reader like this content',
+ *            'created_at:datetime',
+ *            [
+ *                    'attribute' => 'updated_at',
+ *                    'format' => 'date',
+ *            ],
+ *        ],
+ *        'headers' => [
+ *            'created_at' => 'Date Created Content',
+ *        ],
  * ]);
- * 
+ *
  * ~~~
- * 
- * 
+ *
+ *
  * Import file excel and return into an array.
- * 
+ *
  * ~~~
- * 
+ *
  * $data = \moonland\phpexcel\Excel::import($fileName, $config); // $config is an optional
- * 
+ *
  * $data = \moonland\phpexcel\Excel::widget([
- * 		'mode' => 'import',
- * 		'fileName' => $fileName,
- * 		'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
- * 		'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
- * 		'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
+ *        'mode' => 'import',
+ *        'fileName' => $fileName,
+ *        'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
+ *        'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
+ *        'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
  * ]);
- * 
+ *
  * $data = \moonland\phpexcel\Excel::import($fileName, [
- * 		'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
- * 		'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
- * 		'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
- *	]);
+ *        'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
+ *        'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
+ *        'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
+ *    ]);
  *
  * // import data with multiple file.
- * 
+ *
  * $data = \moonland\phpexcel\Excel::widget([
- * 		'mode' => 'import',
- * 		'fileName' => [
- * 			'file1' => $fileName1,
- * 			'file2' => $fileName2,
- * 			'file3' => $fileName3,
- * 		],
- * 		'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
- * 		'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
- * 		'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
+ *        'mode' => 'import',
+ *        'fileName' => [
+ *            'file1' => $fileName1,
+ *            'file2' => $fileName2,
+ *            'file3' => $fileName3,
+ *        ],
+ *        'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
+ *        'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
+ *        'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
  * ]);
- * 
+ *
  * $data = \moonland\phpexcel\Excel::import([
- * 			'file1' => $fileName1,
- * 			'file2' => $fileName2,
- * 			'file3' => $fileName3,
- * 		], [
- * 		'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
- * 		'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
- * 		'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
- *	]);
+ *            'file1' => $fileName1,
+ *            'file2' => $fileName2,
+ *            'file3' => $fileName3,
+ *        ], [
+ *        'setFirstRecordAsKeys' => true, // if you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
+ *        'setIndexSheetByName' => true, // set this if your excel data with multiple worksheet, the index of array will be set with the sheet name. If this not set, the index will use numeric.
+ *        'getOnlySheet' => 'sheet1', // you can set this property if you want to get the specified sheet from the excel data with multiple worksheet.
+ *    ]);
  *
  * ~~~
- * 
+ *
  * Result example from the code on the top :
- * 
+ *
  * ~~~
- * 
+ *
  * // only one sheet or specified sheet.
- * 
- * Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ *
+ * Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2));
- * 
+ *
  * // data with multiple worksheet
- * 
- * Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ *
+ * Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)),
- * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)));
- * 
+ *
  * // data with multiple file and specified sheet or only one worksheet
- * 
- * Array([file1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ *
+ * Array([file1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)),
- * [file2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ * [file2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)));
- * 
+ *
  * // data with multiple file and multiple worksheet
- * 
- * Array([file1] => Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ *
+ * Array([file1] => Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)),
- * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2))),
- * [file2] => Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ * [file2] => Array([Sheet1] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2)),
- * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2), 
+ * [Sheet2] => Array([0] => Array([name] => Anam, [email] => moh.khoirul.anaam@gmail.com, [framework interest] => Yii2),
  * [1] => Array([name] => Example, [email] => example@moonlandsoft.com, [framework interest] => Yii2))));
- * 
+ *
  * ~~~
- * 
+ *
  * @property string $mode is an export mode or import mode. valid value are 'export' and 'import'
  * @property boolean $isMultipleSheet for set the export excel with multiple sheet.
  * @property array $properties for set property on the excel object.
  * @property array $models Model object or DataProvider object with much data.
- * @property array $columns to get the attributes from the model, this valid value only the exist attribute on the model. 
+ * @property array $columns to get the attributes from the model, this valid value only the exist attribute on the model.
  * If this is not set, then all attribute of the model will be set as columns.
- * @property array $headers to set the header column on first line. Set this if want to custom header. 
+ * @property array $headers to set the header column on first line. Set this if want to custom header.
  * If not set, the header will get attributes label of model attributes.
  * @property string|array $fileName is a name for file name to export or import. Multiple file name only use for import mode, not work if you use the export mode.
  * @property string $savePath is a directory to save the file or you can blank this to set the file as attachment.
  * @property string $format for excel to export. Valid value are 'Excel5','Excel2007','Excel2003XML','00Calc','Gnumeric'.
  * @property boolean $setFirstTitle to set the title column on the first line. The columns will have a header on the first line.
  * @property boolean $asAttachment to set the file excel to download mode.
- * @property boolean $setFirstRecordAsKeys to set the first record on excel file to a keys of array per line. 
+ * @property boolean $setFirstRecordAsKeys to set the first record on excel file to a keys of array per line.
  * If you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
  * @property boolean $setIndexSheetByName to set the sheet index by sheet name or array result if the sheet not only one
  * @property string $getOnlySheet is a sheet name to getting the data. This is only get the sheet with same name.
  * @property array|Formatter $formatter the formatter used to format model attribute values into displayable texts.
  * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]
  * instance. If this property is not set, the "formatter" application component will be used.
- * 
+ *
  * @author Moh Khoirul Anam <moh.khoirul.anaam@gmail.com>
  * @copyright 2014
  * @since 1
  */
 class Excel extends \yii\base\Widget
 {
-	/**
-	 * @var string mode is an export mode or import mode. valid value are 'export' and 'import'.
-	 */
-	public $mode = 'export';
-	/**
-	 * @var boolean for set the export excel with multiple sheet.
-	 */
-	public $isMultipleSheet = false;
-	/**
-	 * @var array properties for set property on the excel object.
-	 */
-	public $properties;
-	/**
-	 * @var Model object or DataProvider object with much data.
-	 */
-	public $models;
-	/**
-	 * @var array columns to get the attributes from the model, this valid value only the exist attribute on the model.
-	 * If this is not set, then all attribute of the model will be set as columns.
-	 */
-	public $columns = [];
-	/**
-	 * @var array header to set the header column on first line. Set this if want to custom header. 
-	 * If not set, the header will get attributes label of model attributes.
-	 */
-	public $headers = [];
-	/**
-	 * @var string|array name for file name to export or save.
-	 */
-	public $fileName;
-	/**
-	 * @var string save path is a directory to save the file or you can blank this to set the file as attachment.
-	 */
-	public $savePath;
-	/**
-	 * @var string format for excel to export. Valid value are 'Excel5','Excel2007','Excel2003XML','00Calc','Gnumeric'.
-	 */
-	public $format;
-	/**
-	 * @var boolean to set the title column on the first line.
-	 */
-	public $setFirstTitle = true;
-	/**
-	 * @var boolean to set the file excel to download mode.
-	 */
-	public $asAttachment = true;
-	/**
-	 * @var boolean to set the first record on excel file to a keys of array per line. 
-	 * If you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
-	 */
-	public $setFirstRecordAsKeys = true;
-	/**
-	 * @var boolean to set the sheet index by sheet name or array result if the sheet not only one.
-	 */
-	public $setIndexSheetByName = false;
-	/**
-	 * @var string sheetname to getting. This is only get the sheet with same name.
-	 */
-	public $getOnlySheet;
-	/**
-	 * @var boolean to set the import data will return as array.
-	 */
-	public $asArray;
-	/**
-	 * @var array to unread record by index number.
-	 */
-	public $leaveRecordByIndex = [];
-	/**
-	 * @var array to read record by index, other will leave.
-	 */
-	public $getOnlyRecordByIndex = [];
-	/**
-	 * @var array|Formatter the formatter used to format model attribute values into displayable texts.
-	 * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]
-	 * instance. If this property is not set, the "formatter" application component will be used.
-	 */
-	public $formatter;
-	
-	/**
-	 * (non-PHPdoc)
-	 * @see \yii\base\Object::init()
-	 */
-	public function init()
-	{
-		parent::init();
-		if ($this->formatter == null) {
-			$this->formatter = \Yii::$app->getFormatter();
-		} elseif (is_array($this->formatter)) {
-			$this->formatter = \Yii::createObject($this->formatter);
-		}
-		if (!$this->formatter instanceof Formatter) {
-			throw new InvalidConfigException('The "formatter" property must be either a Format object or a configuration array.');
-		}
-	}
-	
-	/**
-	 * Setting data from models
-	 */
-	public function executeColumns(&$activeSheet = null, $models, $columns = [], $headers = [])
-	{
-		if ($activeSheet == null) {
-			$activeSheet = $this->activeSheet;
-		}
-		$hasHeader = false;
-		$row = 1;
-		$char = 26;
-		foreach ($models as $model) {
-			if (empty($columns)) {
-				$columns = $model->attributes();
-			}
-			if ($this->setFirstTitle && !$hasHeader) {
-				$isPlus = false;
-				$colplus = 0;
-				$colnum = 1;
-				foreach ($columns as $key=>$column) {
-					$col = '';
-					if ($colnum > $char) {
-						$colplus += 1;
-						$colnum = 1;
-						$isPlus = true;
-					}
-					if ($isPlus) {
-						$col .= chr(64+$colplus);
-					}
-					$col .= chr(64+$colnum);
-					$header = '';
-					if (is_array($column)) {
-						if (isset($column['header'])) {
-							$header = $column['header'];
-						} elseif (isset($column['attribute']) && isset($headers[$column['attribute']])) {
-							$header = $headers[$column['attribute']];
-						} elseif (isset($column['attribute'])) {
-							$header = $model->getAttributeLabel($column['attribute']);
-						}
-					} else {
-						$header = $model->getAttributeLabel($column);
-					}
-					$activeSheet->setCellValue($col.$row,$header);
-					$colnum++;
-				}
-				$hasHeader=true;
-				$row++;
-			}
-			$isPlus = false;
-			$colplus = 0;
-			$colnum = 1;
-			foreach ($columns as $key=>$column) {
-				$col = '';
-				if ($colnum > $char) {
-					$colplus++;
-					$colnum = 1;
-					$isPlus = true;
-				}
-				if ($isPlus) {
-					$col .= chr(64+$colplus);
-				}
-				$col .= chr(64+$colnum);
-				if (is_array($column)) {
-					$column_value = $this->executeGetColumnData($model, $column);
-				} else {
-					$column_value = $this->executeGetColumnData($model, ['attribute' => $column]);
-				}
-				$activeSheet->setCellValue($col.$row,$column_value);
-				$colnum++;
-			}
-			$row++;
-		}
-	}
-	
-	/**
-	 * Setting label or keys on every record if setFirstRecordAsKeys is true.
-	 * @param array $sheetData
-	 * @return multitype:multitype:array
-	 */
-	public function executeArrayLabel($sheetData)
-	{
-		$keys = ArrayHelper::remove($sheetData, '1');
-		
-		$new_data = [];
-		
-		foreach ($sheetData as $values)
-		{
-			$new_data[] = array_combine($keys, $values);
-		}
-		
-		return $new_data;
-	}
-	
-	/**
-	 * Leave record with same index number.
-	 * @param array $sheetData
-	 * @param array $index
-	 * @return array
-	 */
-	public function executeLeaveRecords($sheetData = [], $index = [])
-	{
-		foreach ($sheetData as $key => $data)
-		{
-			if (in_array($key, $index))
-			{
-				unset($sheetData[$key]);
-			}
-		}
-		return $sheetData;
-	}
-	
-	/**
-	 * Read record with same index number.
-	 * @param array $sheetData
-	 * @param array $index
-	 * @return array
-	 */
-	public function executeGetOnlyRecords($sheetData = [], $index = [])
-	{
-		foreach ($sheetData as $key => $data)
-		{
-			if (!in_array($key, $index))
-			{
-				unset($sheetData[$key]);
-			}
-		}
-		return $sheetData;
-	}
-	
-	/**
-	 * Getting column value.
-	 * @param Model $model
-	 * @param array $params
-	 * @return Ambigous <NULL, string, mixed>
-	 */
-	public function executeGetColumnData($model, $params = [])
-	{
-		$value = null;
-		if (isset($params['value']) && $params['value'] !== null) {
-			if (is_string($params['value'])) {
-				$value = ArrayHelper::getValue($model, $params['value']);
-			} else {
-				$value = call_user_func($params['value'], $model, $this);
-			}
-		} elseif (isset($params['attribute']) && $params['attribute'] !== null) {
-			$value = ArrayHelper::getValue($model, $params['attribute']);
-		}
-		
-		if (isset($params['format']) && $params['format'] != null)
-			$value = $this->formatter()->format($value, $params['format']);
-		
-		return $value;
-	}
-	
-	/**
-	 * Populating columns for checking the column is string or array. if is string this will be checking have a formatter or header.
-	 * @param array $columns
-	 * @throws InvalidParamException
-	 * @return multitype:multitype:array
-	 */
-	public function populateColumns($columns = [])
-	{
-		$_columns = [];
-		foreach ($columns as $key => $value)
-		{
-			if (is_string($value))
-			{
-				$value_log = explode(':', $value);
-				$_columns[$key] = ['attribute' => $value_log[0]];
-				
-				if (isset($value_log[1]) && $value_log[1] !== null) {
-					$_columns[$key]['format'] = $value_log[1];
-				}
-				
-				if (isset($value_log[2]) && $value_log[2] !== null) {
-					$_columns[$key]['header'] = $value_log[2];
-				}
-			} elseif (is_array($value)) {
-				if (!isset($value['attribute']) && !isset($value['value'])) {
-					throw new InvalidParamException('Attribute or Value must be defined.');
-				}
-				$_columns[$key] = $value;
-			}
-		}
-		
-		return $_columns;
-	}
-	
-	/**
-	 * Formatter for i18n.
-	 * @return Formatter
-	 */
-	public function formatter()
-	{
-		if (!isset($this->formatter))
-			$this->formatter = \Yii::$app->getFormatter();
-		
-		return $this->formatter;
-	}
-	
-	/**
-	 * Setting header to download generated file xls
-	 */
-	public function setHeaders()
-	{
-		header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-		header('Content-Disposition: attachment;filename="' . $this->getFileName() .'"');
-		header('Cache-Control: max-age=0');
-	}
-	
-	/**
-	 * Getting the file name of exporting xls file
-	 * @return string
-	 */
-	public function getFileName()
-	{
-		if (isset($this->fileName)) {
-			$fileName = $this->fileName;
-		} else {
-			$fileName = 'exports';
-		}
+    /**
+     * @var string mode is an export mode or import mode. valid value are 'export' and 'import'.
+     */
+    public $mode = self::EXPORT;
+    /**
+     * @var boolean for set the export excel with multiple sheet.
+     */
+    public $isMultipleSheet = false;
+    /**
+     *
+     * @var array properties for set property on the excel object.
+     */
+    public $properties;
+    /**
+     * @var Model object or DataProvider object with much data.
+     */
+    public $models;
+    /**
+     * @var array columns to get the attributes from the model, this valid value only the exist attribute on the model.
+     * If this is not set, then all attribute of the model will be set as columns.
+     */
+    public $columns = [];
+    /**
+     * @var array header to set the header column on first line. Set this if want to custom header.
+     * If not set, the header will get attributes label of model attributes.
+     */
+    public $headers = [];
+    /**
+     * @var string|array name for file name to export or save.
+     */
+    public $fileName;
+    /**
+     * @var string save path is a directory to save the file or you can blank this to set the file as attachment.
+     */
+    public $savePath;
+    /**
+     * @var string format for excel to export. Valid value are 'Excel5','Excel2007','Excel2003XML','00Calc','Gnumeric'.
+     */
+    public $format;
+    /**
+     * @var boolean to set the title column on the first line.
+     */
+    public $setFirstTitle = true;
+    /**
+     * @var boolean to set the file excel to download mode.
+     */
+    public $asAttachment = true;
+    /**
+     * @var boolean to set the first record on excel file to a keys of array per line.
+     * If you want to set the keys of record column with first record, if it not set, the header with use the alphabet column on excel.
+     */
+    public $setFirstRecordAsKeys = true;
+    /**
+     * @var boolean to set the sheet index by sheet name or array result if the sheet not only one.
+     */
+    public $setIndexSheetByName = false;
+    /**
+     * @var string sheetname to getting. This is only get the sheet with same name.
+     */
+    public $getOnlySheet;
+    /**
+     * @var boolean to set the import data will return as array.
+     */
+    public $asArray;
+    /**
+     * @var array to unread record by index number.
+     */
+    public $leaveRecordByIndex = [];
+    /**
+     * @var array to read record by index, other will leave.
+     */
+    public $getOnlyRecordByIndex = [];
+    /**
+     * @var array|Formatter the formatter used to format model attribute values into displayable texts.
+     * This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]]
+     * instance. If this property is not set, the "formatter" application component will be used.
+     */
+    public $formatter;
 
-		$pathinfo = pathinfo($this->fileName);
-		if (!isset($pathinfo['extension'])) {
-			$extensionMap = [
-				'Excel2007' => '.xlsx',
-				'Excel5' => '.xls',
-				'Excel2003XML' => '.xml',
-				'OOCalc' => '.ods',
-				'SYLK' => '.slk',
-				'Gnumeric' => '.Gnumeric',
-				'HTML' => '.html',
-				'CSV' => '.csv',
-			];
+    /**
+     * (non-PHPdoc)
+     * @see \yii\base\Object::init()
+     */
+    const EXPORT = 'export';
 
-			if(isset($this->format)) {
-				if(isset($extensionMap[$format])) {
-					$fileName .= $extensionMap[$this->format];
-				}
-			} else {
-				$fileName .= $extensionMap['Excel2007'];
-			}
-		}
+    public function init()
+    {
+        parent::init();
+        if ($this->formatter == null) {
+            $this->formatter = \Yii::$app->getFormatter();
+        } elseif (is_array($this->formatter)) {
+            $this->formatter = \Yii::createObject($this->formatter);
+        }
+        if (!$this->formatter instanceof Formatter) {
+            throw new InvalidConfigException('The "formatter" property must be either a Format object or a configuration array.');
+        }
+    }
 
-		return $fileName;
-	}
-	
-	/**
-	 * Setting properties for excel file
-	 * @param \PhpOffice\PhpSpreadsheet\Spreadsheet $objectExcel
-	 * @param array $properties
-	 */
-	public function properties(&$objectExcel, $properties = [])
-	{
-		foreach ($properties as $key => $value)
-		{
-			$keyname = "set" . ucfirst($key);
-			$objectExcel->getProperties()->{$keyname}($value);
-		}
-	}
-	
-	/**
-	 * saving the xls file to download or to path
-	 */
-	public function writeFile($sheet)
-	{
-		if (!isset($this->format))
-			$this->format = 'Excel2007';
-		$objectwriter = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($sheet, $this->format);
-		$path = 'php://output';
-		if (isset($this->savePath) && $this->savePath != null) {
-			$path = $this->savePath . '/' . $this->getFileName();
-		}
-		$objectwriter->save($path);
-		exit();
-	}
-	
-	/**
-	 * reading the xls file
-	 */
-	public function readFile($fileName)
-	{
-		if (!isset($this->format))
-			$this->format = \PhpOffice\PhpSpreadsheet\IOFactory::identify($fileName);
-		$objectreader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($this->format);
-		$objectPhpExcel = $objectreader->load($fileName);
-		
-		$sheetCount = $objectPhpExcel->getSheetCount();
-		
-		$sheetDatas = [];
-		
-		if ($sheetCount > 1) {
-			foreach ($objectPhpExcel->getSheetNames() as $sheetIndex => $sheetName) {
-				if (isset($this->getOnlySheet) && $this->getOnlySheet != null) {
-					if(!$objectPhpExcel->getSheetByName($this->getOnlySheet)) {
-						return $sheetDatas;
-					}
-					$objectPhpExcel->setActiveSheetIndexByName($this->getOnlySheet);
-					$indexed = $this->getOnlySheet;
-					$sheetDatas[$indexed] = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
-					if ($this->setFirstRecordAsKeys) {
-						$sheetDatas[$indexed] = $this->executeArrayLabel($sheetDatas[$indexed]);
-					}
-					if (!empty($this->getOnlyRecordByIndex)) {
-						$sheetDatas[$indexed] = $this->executeGetOnlyRecords($sheetDatas[$indexed], $this->getOnlyRecordByIndex);
-					}
-					if (!empty($this->leaveRecordByIndex)) {
-						$sheetDatas[$indexed] = $this->executeLeaveRecords($sheetDatas[$indexed], $this->leaveRecordByIndex);
-					}
-					return $sheetDatas[$indexed];
-				} else {
-					$objectPhpExcel->setActiveSheetIndexByName($sheetName);
-					$indexed = $this->setIndexSheetByName==true ? $sheetName : $sheetIndex;
-					$sheetDatas[$indexed] = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
-					if ($this->setFirstRecordAsKeys) {
-						$sheetDatas[$indexed] = $this->executeArrayLabel($sheetDatas[$indexed]);
-					}
-					if (!empty($this->getOnlyRecordByIndex) && isset($this->getOnlyRecordByIndex[$indexed]) && is_array($this->getOnlyRecordByIndex[$indexed])) {
-						$sheetDatas = $this->executeGetOnlyRecords($sheetDatas, $this->getOnlyRecordByIndex[$indexed]);
-					}
-					if (!empty($this->leaveRecordByIndex) && isset($this->leaveRecordByIndex[$indexed]) && is_array($this->leaveRecordByIndex[$indexed])) {
-						$sheetDatas[$indexed] = $this->executeLeaveRecords($sheetDatas[$indexed], $this->leaveRecordByIndex[$indexed]);
-					}
-				}
-			}
-		} else {
-			$sheetDatas = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
-			if ($this->setFirstRecordAsKeys) {
-				$sheetDatas = $this->executeArrayLabel($sheetDatas);
-			}
-			if (!empty($this->getOnlyRecordByIndex)) {
-				$sheetDatas = $this->executeGetOnlyRecords($sheetDatas, $this->getOnlyRecordByIndex);
-			}
-			if (!empty($this->leaveRecordByIndex)) {
-				$sheetDatas = $this->executeLeaveRecords($sheetDatas, $this->leaveRecordByIndex);
-			}
-		}
-		
-		return $sheetDatas;
-	}
-	
-	/**
-	 * (non-PHPdoc)
-	 * @see \yii\base\Widget::run()
-	 */
-	public function run()
-	{
-		if ($this->mode == 'export') 
-		{
-	    	$sheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
-	    	
-	    	if (!isset($this->models))
-	    		throw new InvalidConfigException('Config models must be set');
-	    	
-	    	if (isset($this->properties))
-	    	{
-	    		$this->properties($sheet, $this->properties);
-	    	}
-	    	
-	    	if ($this->isMultipleSheet) {
-	    		$index = 0;
-	    		$worksheet = [];
-	    		foreach ($this->models as $title => $models) {
-	    			$sheet->createSheet($index);
-	    			$sheet->getSheet($index)->setTitle($title);
-	    			$worksheet[$index] = $sheet->getSheet($index);
-	    			$columns = isset($this->columns[$title]) ? $this->columns[$title] : [];
-	    			$headers = isset($this->headers[$title]) ? $this->headers[$title] : [];
-	    			$this->executeColumns($worksheet[$index], $models, $this->populateColumns($columns), $headers);
-	    			$index++;
-	    		}
-	    	} else {
-	    		$worksheet = $sheet->getActiveSheet();
-	    		$this->executeColumns($worksheet, $this->models, isset($this->columns) ? $this->populateColumns($this->columns) : [], isset($this->headers) ? $this->headers : []);
-	    	}
-	    	
-	    	if ($this->asAttachment) {
-	    		$this->setHeaders();
-	    	}
-	    	$this->writeFile($sheet);
-		} 
-		elseif ($this->mode == 'import') 
-		{
-			if (is_array($this->fileName)) {
-				$datas = [];
-				foreach ($this->fileName as $key => $filename) {
-					$datas[$key] = $this->readFile($filename);
-				}
-				return $datas;
-			} else {
-				return $this->readFile($this->fileName);
-			}
-		}
-	}
-	
-	/**
-	 * Exporting data into an excel file.
-	 * 
-	 * ~~~
-	 * 
-	 * \moonland\phpexcel\Excel::export([
-	 * 		'models' => $allModels,
-	 * 		'columns' => ['column1','column2','column3'],
-	 * 		//without header working, because the header will be get label from attribute label.
-	 * 		'header' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
-	 * ]);
-	 * 
-	 * ~~~
-	 * 
-	 * New Feature for exporting data, you can use this if you familiar yii gridview. 
-	 * That is same with gridview data column.
-	 * Columns in array mode valid params are 'attribute', 'header', 'format', 'value', and footer (TODO).
-	 * Columns in string mode valid layout are 'attribute:format:header:footer(TODO)'.
-	 * 
-	 * ~~~
-	 * 
-	 * \moonland\phpexcel\Excel::export([
-	 *  	'models' => Post::find()->all(),
-	 *     	'columns' => [
-	 *     		'author.name:text:Author Name',
-	 *     		[
-	 *     				'attribute' => 'content',
-	 *     				'header' => 'Content Post',
-	 *     				'format' => 'text',
-	 *     				'value' => function($model) {
-	 *     					return ExampleClass::removeText('example', $model->content);
-	 *     				},
-	 *     		],
-	 *     		'like_it:text:Reader like this content',
-	 *     		'created_at:datetime',
-	 *     		[
-	 *     				'attribute' => 'updated_at',
-	 *     				'format' => 'date',
-	 *     		],
-	 *     	],
-	 *     	'headers' => [
-	 *     		'created_at' => 'Date Created Content',
-	 * 		],
-	 * ]);
-	 * 
-	 * ~~~
-	 * 
-	 * @param array $config
-	 * @return string
-	 */
-	public static function export($config=[])
-	{
-		$config = ArrayHelper::merge(['mode' => 'export'], $config);
-		return self::widget($config);
-	}
-	
-	/**
-	 * Import file excel and return into an array.
-	 * 
-	 * ~~~
-	 * 
-	 * $data = \moonland\phpexcel\Excel::import($fileName, ['setFirstRecordAsKeys' => true]);
-	 * 
-	 * ~~~
-	 * 
-	 * @param string!array $fileName to load.
-	 * @param array $config is a more configuration.
-	 * @return string
-	 */
-	public static function import($fileName, $config=[])
-	{
-		$config = ArrayHelper::merge(['mode' => 'import', 'fileName' => $fileName, 'asArray' => true], $config);
-		return self::widget($config);
-	}
-	
-	/**
-	 * @param array $config
-	 * @return string
-	 */
-	public static function widget($config = [])
-	{
-		if ($config['mode'] == 'import' && !isset($config['asArray'])) {
-			$config['asArray'] = true;
-		}
-		
-		if (isset($config['asArray']) && $config['asArray']==true)
-		{
-	        $config['class'] = get_called_class();
-	        $widget = \Yii::createObject($config);
-	        return $widget->run();
-		} else {
-			return parent::widget($config);
-		}
-	}
+    /**
+     * Setting data from models
+     */
+    public function executeColumns(&$activeSheet = null, $models, $columns = [], $headers = [])
+    {
+        if ($activeSheet == null) {
+            $activeSheet = $this->activeSheet;
+        }
+        $hasHeader = false;
+        $row = 1;
+        $char = 26;
+        foreach ($models as $model) {
+            if (empty($columns)) {
+                $columns = $model->attributes();
+            }
+            if ($this->setFirstTitle && !$hasHeader) {
+                $isPlus = false;
+                $colplus = 0;
+                $colnum = 1;
+                foreach ($columns as $key => $column) {
+                    $col = '';
+                    if ($colnum > $char) {
+                        $colplus += 1;
+                        $colnum = 1;
+                        $isPlus = true;
+                    }
+                    if ($isPlus) {
+                        $col .= chr(64 + $colplus);
+                    }
+                    $col .= chr(64 + $colnum);
+                    $header = '';
+                    if (is_array($column)) {
+                        if (isset($column['header'])) {
+                            $header = $column['header'];
+                        } elseif (isset($column['attribute']) && isset($headers[$column['attribute']])) {
+                            $header = $headers[$column['attribute']];
+                        } elseif (isset($column['attribute'])) {
+                            $header = $model->getAttributeLabel($column['attribute']);
+                        }
+                    } else {
+                        $header = $model->getAttributeLabel($column);
+                    }
+                    $activeSheet->setCellValue($col . $row, $header);
+                    $colnum++;
+                }
+                $hasHeader = true;
+                $row++;
+            }
+            $isPlus = false;
+            $colplus = 0;
+            $colnum = 1;
+            foreach ($columns as $key => $column) {
+                $col = '';
+                if ($colnum > $char) {
+                    $colplus++;
+                    $colnum = 1;
+                    $isPlus = true;
+                }
+                if ($isPlus) {
+                    $col .= chr(64 + $colplus);
+                }
+                $col .= chr(64 + $colnum);
+                if (is_array($column)) {
+                    $column_value = $this->executeGetColumnData($model, $column);
+                } else {
+                    $column_value = $this->executeGetColumnData($model, ['attribute' => $column]);
+                }
+                $activeSheet->setCellValue($col . $row, $column_value);
+                $colnum++;
+            }
+            $row++;
+        }
+    }
+
+    /**
+     * Setting label or keys on every record if setFirstRecordAsKeys is true.
+     * @param array $sheetData
+     * @return multitype:multitype:array
+     */
+    public function executeArrayLabel($sheetData)
+    {
+        $keys = ArrayHelper::remove($sheetData, '1');
+
+        $new_data = [];
+
+        foreach ($sheetData as $values) {
+            $new_data[] = array_combine($keys, $values);
+        }
+
+        return $new_data;
+    }
+
+    /**
+     * Leave record with same index number.
+     * @param array $sheetData
+     * @param array $index
+     * @return array
+     */
+    public function executeLeaveRecords($sheetData = [], $index = [])
+    {
+        foreach ($sheetData as $key => $data) {
+            if (in_array($key, $index)) {
+                unset($sheetData[$key]);
+            }
+        }
+        return $sheetData;
+    }
+
+    /**
+     * Read record with same index number.
+     * @param array $sheetData
+     * @param array $index
+     * @return array
+     */
+    public function executeGetOnlyRecords($sheetData = [], $index = [])
+    {
+        foreach ($sheetData as $key => $data) {
+            if (!in_array($key, $index)) {
+                unset($sheetData[$key]);
+            }
+        }
+        return $sheetData;
+    }
+
+    /**
+     * Getting column value.
+     * @param Model $model
+     * @param array $params
+     * @return Ambigous <NULL, string, mixed>
+     */
+    public function executeGetColumnData($model, $params = [])
+    {
+        $value = null;
+        if (isset($params['value']) && $params['value'] !== null) {
+            if (is_string($params['value'])) {
+                $value = ArrayHelper::getValue($model, $params['value']);
+            } else {
+                $value = call_user_func($params['value'], $model, $this);
+            }
+        } elseif (isset($params['attribute']) && $params['attribute'] !== null) {
+            $value = ArrayHelper::getValue($model, $params['attribute']);
+        }
+
+        if (isset($params['format']) && $params['format'] != null) {
+            $value = $this->formatter()->format($value, $params['format']);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Populating columns for checking the column is string or array. if is string this will be checking have a formatter or header.
+     * @param array $columns
+     * @throws InvalidArgumentException
+     * @return multitype:multitype:array
+     */
+    public function populateColumns($columns = [])
+    {
+        $_columns = [];
+        foreach ($columns as $key => $value) {
+            if (is_string($value)) {
+                $value_log = explode(':', $value);
+                $_columns[$key] = ['attribute' => $value_log[0]];
+
+                if (isset($value_log[1]) && $value_log[1] !== null) {
+                    $_columns[$key]['format'] = $value_log[1];
+                }
+
+                if (isset($value_log[2]) && $value_log[2] !== null) {
+                    $_columns[$key]['header'] = $value_log[2];
+                }
+            } elseif (is_array($value)) {
+                if (!isset($value['attribute']) && !isset($value['value'])) {
+                    throw new InvalidArgumentException('Attribute or Value must be defined.');
+                }
+                $_columns[$key] = $value;
+            }
+        }
+
+        return $_columns;
+    }
+
+    /**
+     * Formatter for i18n.
+     * @return Formatter
+     */
+    public function formatter()
+    {
+        if (!isset($this->formatter)) {
+            $this->formatter = \Yii::$app->getFormatter();
+        }
+
+        return $this->formatter;
+    }
+
+    /**
+     * Setting header to download generated file xls
+     */
+    public function setHeaders()
+    {
+        header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        header('Content-Disposition: attachment;filename="' . $this->getFileName() . '"');
+        header('Cache-Control: max-age=0');
+    }
+
+    /**
+     * Getting the file name of exporting xls file
+     * @return string
+     */
+    public function getFileName()
+    {
+        if (isset($this->fileName)) {
+            $fileName = $this->fileName;
+        } else {
+            $fileName = 'exports';
+        }
+
+        $pathinfo = pathinfo($this->fileName);
+        if (!isset($pathinfo['extension'])) {
+            $extensionMap = [
+                'Xlsx' => '.xlsx',
+                //'Excel5' => '.xls',
+                'Xls' => '.xls',
+                //'Excel2003XML' => '.xml',
+                //'OOCalc' => '.ods',
+                //'SYLK' => '.slk',
+                //'Gnumeric' => '.Gnumeric',
+                'Html' => '.html',
+                'Cav' => '.csv',
+            ];
+
+            if (isset($this->format)) {
+                if (isset($extensionMap[$this->format])) {
+                    $fileName .= $extensionMap[$this->format];
+                }
+            } else {
+                $fileName .= $extensionMap['Xlsx'];
+            }
+        }
+
+        return $fileName;
+    }
+
+    /**
+     * Setting properties for excel file
+     * @param \PhpOffice\PhpSpreadsheet\Spreadsheet $objectExcel
+     * @param array $properties
+     */
+    public function properties(&$objectExcel, $properties = [])
+    {
+        foreach ($properties as $key => $value) {
+            $keyname = "set" . ucfirst($key);
+            $objectExcel->getProperties()->{$keyname}($value);
+        }
+    }
+
+    /**
+     * saving the xls file to download or to path
+     */
+    public function writeFile($sheet)
+    {
+        if (!isset($this->format)) {
+            $this->format = 'Xlsx';
+        }
+        $objectwriter = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($sheet, $this->format);
+        $path = 'php://output';
+        if (isset($this->savePath) && $this->savePath !== null) {
+            $path = $this->savePath . '/' . $this->getFileName();
+        }
+        $objectwriter->save($path);
+        exit();
+    }
+
+    /**
+     * reading the xls file
+     */
+    public function readFile($fileName)
+    {
+        if (!isset($this->format)) {
+            $this->format = \PhpOffice\PhpSpreadsheet\IOFactory::identify($fileName);
+        }
+        $objectreader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($this->format);
+        $objectPhpExcel = $objectreader->load($fileName);
+
+        $sheetCount = $objectPhpExcel->getSheetCount();
+
+        $sheetDatas = [];
+
+        if ($sheetCount > 1) {
+            foreach ($objectPhpExcel->getSheetNames() as $sheetIndex => $sheetName) {
+                if (isset($this->getOnlySheet) && $this->getOnlySheet !== null) {
+                    if (!$objectPhpExcel->getSheetByName($this->getOnlySheet)) {
+                        return $sheetDatas;
+                    }
+                    $objectPhpExcel->setActiveSheetIndexByName($this->getOnlySheet);
+                    $indexed = $this->getOnlySheet;
+                    $sheetDatas[$indexed] = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
+                    if ($this->setFirstRecordAsKeys) {
+                        $sheetDatas[$indexed] = $this->executeArrayLabel($sheetDatas[$indexed]);
+                    }
+                    if (!empty($this->getOnlyRecordByIndex)) {
+                        $sheetDatas[$indexed] = $this->executeGetOnlyRecords($sheetDatas[$indexed], $this->getOnlyRecordByIndex);
+                    }
+                    if (!empty($this->leaveRecordByIndex)) {
+                        $sheetDatas[$indexed] = $this->executeLeaveRecords($sheetDatas[$indexed], $this->leaveRecordByIndex);
+                    }
+                    return $sheetDatas[$indexed];
+                } else {
+                    $objectPhpExcel->setActiveSheetIndexByName($sheetName);
+                    $indexed = $this->setIndexSheetByName === true ? $sheetName : $sheetIndex;
+                    $sheetDatas[$indexed] = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
+                    if ($this->setFirstRecordAsKeys) {
+                        $sheetDatas[$indexed] = $this->executeArrayLabel($sheetDatas[$indexed]);
+                    }
+                    if (!empty($this->getOnlyRecordByIndex) && isset($this->getOnlyRecordByIndex[$indexed]) && is_array($this->getOnlyRecordByIndex[$indexed])) {
+                        $sheetDatas = $this->executeGetOnlyRecords($sheetDatas, $this->getOnlyRecordByIndex[$indexed]);
+                    }
+                    if (!empty($this->leaveRecordByIndex) && isset($this->leaveRecordByIndex[$indexed]) && is_array($this->leaveRecordByIndex[$indexed])) {
+                        $sheetDatas[$indexed] = $this->executeLeaveRecords($sheetDatas[$indexed], $this->leaveRecordByIndex[$indexed]);
+                    }
+                }
+            }
+        } else {
+            $sheetDatas = $objectPhpExcel->getActiveSheet()->toArray(null, true, true, true);
+            if ($this->setFirstRecordAsKeys) {
+                $sheetDatas = $this->executeArrayLabel($sheetDatas);
+            }
+            if (!empty($this->getOnlyRecordByIndex)) {
+                $sheetDatas = $this->executeGetOnlyRecords($sheetDatas, $this->getOnlyRecordByIndex);
+            }
+            if (!empty($this->leaveRecordByIndex)) {
+                $sheetDatas = $this->executeLeaveRecords($sheetDatas, $this->leaveRecordByIndex);
+            }
+        }
+
+        return $sheetDatas;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see \yii\base\Widget::run()
+     */
+    public function run()
+    {
+        if ($this->mode == self::EXPORT) {
+            $sheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+
+            if (!isset($this->models))
+                throw new InvalidConfigException('Config models must be set');
+
+            if (isset($this->properties)) {
+                $this->properties($sheet, $this->properties);
+            }
+
+            if ($this->isMultipleSheet) {
+                $index = 0;
+                $worksheet = [];
+                foreach ($this->models as $title => $models) {
+                    $sheet->createSheet($index);
+                    $sheet->getSheet($index)->setTitle($title);
+                    $worksheet[$index] = $sheet->getSheet($index);
+                    $columns = isset($this->columns[$title]) ? $this->columns[$title] : [];
+                    $headers = isset($this->headers[$title]) ? $this->headers[$title] : [];
+                    $this->executeColumns($worksheet[$index], $models, $this->populateColumns($columns), $headers);
+                    $index++;
+                }
+            } else {
+                $worksheet = $sheet->getActiveSheet();
+                $this->executeColumns($worksheet, $this->models, isset($this->columns) ? $this->populateColumns($this->columns) : [], isset($this->headers) ? $this->headers : []);
+            }
+
+            if ($this->asAttachment) {
+                $this->setHeaders();
+            }
+            $this->writeFile($sheet);
+        } elseif ($this->mode === 'import') {
+            if (is_array($this->fileName)) {
+                $datas = [];
+                foreach ($this->fileName as $key => $filename) {
+                    $datas[$key] = $this->readFile($filename);
+                }
+                return $datas;
+            }
+            return $this->readFile($this->fileName);
+
+        }
+    }
+
+    /**
+     * Exporting data into an excel file.
+     *
+     * ~~~
+     *
+     * \moonland\phpexcel\Excel::export([
+     *        'models' => $allModels,
+     *        'columns' => ['column1','column2','column3'],
+     *        //without header working, because the header will be get label from attribute label.
+     *        'header' => ['column1' => 'Header Column 1','column2' => 'Header Column 2', 'column3' => 'Header Column 3'],
+     * ]);
+     *
+     * ~~~
+     *
+     * New Feature for exporting data, you can use this if you familiar yii gridview.
+     * That is same with gridview data column.
+     * Columns in array mode valid params are 'attribute', 'header', 'format', 'value', and footer (TODO).
+     * Columns in string mode valid layout are 'attribute:format:header:footer(TODO)'.
+     *
+     * ~~~
+     *
+     * \moonland\phpexcel\Excel::export([
+     *    'models' => Post::find()->all(),
+     *        'columns' => [
+     *            'author.name:text:Author Name',
+     *            [
+     *                    'attribute' => 'content',
+     *                    'header' => 'Content Post',
+     *                    'format' => 'text',
+     *                    'value' => function($model) {
+     *                        return ExampleClass::removeText('example', $model->content);
+     *                    },
+     *            ],
+     *            'like_it:text:Reader like this content',
+     *            'created_at:datetime',
+     *            [
+     *                    'attribute' => 'updated_at',
+     *                    'format' => 'date',
+     *            ],
+     *        ],
+     *        'headers' => [
+     *            'created_at' => 'Date Created Content',
+     *        ],
+     * ]);
+     *
+     * ~~~
+     *
+     * @param array $config
+     * @return string
+     */
+    public static function export($config = [])
+    {
+        $config = ArrayHelper::merge(['mode' => self::EXPORT], $config);
+        return self::widget($config);
+    }
+
+    /**
+     * Import file excel and return into an array.
+     *
+     * ~~~
+     *
+     * $data = \moonland\phpexcel\Excel::import($fileName, ['setFirstRecordAsKeys' => true]);
+     *
+     * ~~~
+     *
+     * @param string!array $fileName to load.
+     * @param array $config is a more configuration.
+     * @return string
+     */
+    public static function import($fileName, $config = [])
+    {
+        $config = ArrayHelper::merge(['mode' => 'import', 'fileName' => $fileName, 'asArray' => true], $config);
+        return self::widget($config);
+    }
+
+    /**
+     * @param array $config
+     * @return string
+     */
+    public static function widget($config = [])
+    {
+        if ($config['mode'] === 'import' && !isset($config['asArray'])) {
+            $config['asArray'] = true;
+        }
+
+        if (isset($config['asArray']) && $config['asArray'] === true) {
+            $config['class'] = get_called_class();
+            $widget = \Yii::createObject($config);
+            return $widget->run();
+        }
+
+        return parent::widget($config);
+
+    }
 }

--- a/Excel.php
+++ b/Excel.php
@@ -376,7 +376,7 @@ class Excel extends Widget
     public function init()
     {
         parent::init();
-        if ($this->formatter == null) {
+        if ($this->formatter === null) {
             $this->formatter = Yii::$app->getFormatter();
         } elseif (is_array($this->formatter)) {
             $this->formatter = Yii::createObject($this->formatter);
@@ -394,7 +394,7 @@ class Excel extends Widget
         }
     }
 
-    public function getTitleStartRow()
+    public function getTitleStartRow(): int
     {
         if ($this->titleStartRow === null) {
             $this->titleStartRow = 1;
@@ -645,7 +645,7 @@ class Excel extends Widget
                     /**
                      * if date without time, add 00:00:00 as time
                      */
-                    if (strlen($value)=== '10') {
+                    if (strlen($value)=== 10) {
                         $value .= ' 00:00:00';
                     }
                     if (!$dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $value, new DateTimeZone('UTC'))) {
@@ -925,6 +925,8 @@ class Excel extends Widget
 
     /**
      * @param array $rows
+     * @param int $x
+     * @param int $y
      * @param Worksheet $activeSheet
      * @return int last title row
      * @throws \PhpOffice\PhpSpreadsheet\Exception
@@ -992,6 +994,7 @@ class Excel extends Widget
      *
      * @param array $config
      * @return string
+     * @throws InvalidConfigException
      */
     public static function export($config = []): string
     {
@@ -1011,6 +1014,7 @@ class Excel extends Widget
      * @param string!array $fileName to load.
      * @param array $config is a more configuration.
      * @return string
+     * @throws InvalidConfigException
      */
     public static function import($fileName, $config = []): string
     {

--- a/Excel.php
+++ b/Excel.php
@@ -1,10 +1,20 @@
-<?php
+<?php /** @noinspection PhpUndefinedClassInspection */
 
 namespace moonland\phpexcel;
 
+use DateTime;
+use DateTimeZone;
+use PhpOffice\PhpSpreadsheet\Exception;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use Yii;
 use yii\base\Model;
+use yii\base\Widget;
 use yii\helpers\ArrayHelper;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidArgumentException;
@@ -229,7 +239,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
  * @copyright 2014
  * @since 1
  */
-class Excel extends \yii\base\Widget
+class Excel extends Widget
 {
     /**
      * @var string mode is an export mode or import mode. valid value are 'export' and 'import'.
@@ -322,15 +332,15 @@ class Excel extends \yii\base\Widget
             'color' => array('rgb' => 'FFFDFE' )
         ],
         'alignment' => [
-            'horizontal' => \PhpOffice\PhpSpreadsheet\Style\Alignment::HORIZONTAL_CENTER,
+            'horizontal' => Alignment::HORIZONTAL_CENTER,
         ],
         'borders' => [
             'top' => [
-                'borderStyle' => \PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN,
+                'borderStyle' => Border::BORDER_THIN,
             ],
         ],
         'fill' => [
-            'fillType' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID,
+            'fillType' => Fill::FILL_SOLID,
             'color' => ['rgb' => '7ebf00' ]
         ],
     ];
@@ -338,15 +348,15 @@ class Excel extends \yii\base\Widget
      * (non-PHPdoc)
      * @see \yii\base\Object::init()
      */
-    const EXPORT = 'export';
+    public const EXPORT = 'export';
 
     public function init()
     {
         parent::init();
         if ($this->formatter == null) {
-            $this->formatter = \Yii::$app->getFormatter();
+            $this->formatter = Yii::$app->getFormatter();
         } elseif (is_array($this->formatter)) {
-            $this->formatter = \Yii::createObject($this->formatter);
+            $this->formatter = Yii::createObject($this->formatter);
         }
         if (!$this->formatter instanceof Formatter) {
             throw new InvalidConfigException('The "formatter" property must be either a Format object or a configuration array.');
@@ -361,9 +371,9 @@ class Excel extends \yii\base\Widget
      * @param array $columns
      * @param array $headers
      * @param Worksheet|null $activeSheet
-     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws Exception
      */
-    private function executeColumns(&$models, $columns = [], $headers = [],Worksheet &$activeSheet = null )
+    private function executeColumns(&$models, $columns = [], $headers = [],Worksheet &$activeSheet = null ): void
     {
         if ($activeSheet === null) {
             $activeSheet = $this->activeSheet;
@@ -566,10 +576,10 @@ class Excel extends \yii\base\Widget
         if (isset($params['format'])){
 
             if($params['format'] === 'date'){
-                if(!$dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $value . ' 00:00:00', new \DateTimeZone('UTC'))){
+                if(!$dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $value . ' 00:00:00', new DateTimeZone('UTC'))){
                     return $value;
                 }
-                return \PhpOffice\PhpSpreadsheet\Shared\Date::PHPToExcel($dateTime->getTimestamp());
+                return Date::PHPToExcel($dateTime->getTimestamp());
             }
             if($params['format'] !== null){
                 return $this->formatter()->format($value, $params['format']);
@@ -618,7 +628,7 @@ class Excel extends \yii\base\Widget
     public function formatter(): Formatter
     {
         if (!isset($this->formatter)) {
-            $this->formatter = \Yii::$app->getFormatter();
+            $this->formatter = Yii::$app->getFormatter();
         }
 
         return $this->formatter;
@@ -627,7 +637,7 @@ class Excel extends \yii\base\Widget
     /**
      * Setting header to download generated file xls
      */
-    public function setHeaders()
+    public function setHeaders(): void
     {
         header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         header('Content-Disposition: attachment;filename="' . $this->getFileName() . '"');
@@ -640,11 +650,7 @@ class Excel extends \yii\base\Widget
      */
     public function getFileName(): string
     {
-        if (isset($this->fileName)) {
-            $fileName = $this->fileName;
-        } else {
-            $fileName = 'exports';
-        }
+        $fileName = $this->fileName ?? 'exports';
 
         $pathinfo = pathinfo($this->fileName);
         if (!isset($pathinfo['extension'])) {
@@ -674,10 +680,10 @@ class Excel extends \yii\base\Widget
 
     /**
      * Setting properties for excel file
-     * @param \PhpOffice\PhpSpreadsheet\Spreadsheet $objectExcel
+     * @param Spreadsheet $objectExcel
      * @param array $properties
      */
-    public function properties(&$objectExcel, $properties = [])
+    public function properties(&$objectExcel, $properties = []): void
     {
         foreach ($properties as $key => $value) {
             $keyname = 'set' . ucfirst($key);
@@ -691,7 +697,7 @@ class Excel extends \yii\base\Widget
      * @param $sheet
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function writeFile(&$sheet)
+    public function writeFile(&$sheet): void
     {
         if (!isset($this->format)) {
             $this->format = 'Xlsx';
@@ -712,7 +718,7 @@ class Excel extends \yii\base\Widget
      *
      * @param $fileName
      * @return array
-     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
     public function readFile($fileName): array
@@ -785,7 +791,7 @@ class Excel extends \yii\base\Widget
     public function run()
     {
         if ($this->mode === self::EXPORT) {
-            $sheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+            $sheet = new Spreadsheet();
 
             if (!isset($this->models)) {
                 throw new InvalidConfigException('Config models must be set');
@@ -901,7 +907,7 @@ class Excel extends \yii\base\Widget
      * @param array $config is a more configuration.
      * @return string
      */
-    public static function import($fileName, $config = [])
+    public static function import($fileName, $config = []): string
     {
         $config = ArrayHelper::merge(['mode' => 'import', 'fileName' => $fileName, 'asArray' => true], $config);
         return self::widget($config);
@@ -919,8 +925,8 @@ class Excel extends \yii\base\Widget
         }
 
         if (isset($config['asArray']) && $config['asArray'] === true) {
-            $config['class'] = get_called_class();
-            $widget = \Yii::createObject($config);
+            $config['class'] = static::class;
+            $widget = Yii::createObject($config);
             return $widget->run();
         }
 

--- a/Excel.php
+++ b/Excel.php
@@ -386,6 +386,7 @@ class Excel extends \yii\base\Widget
                 $isPlus = false;
                 $colplus = 0;
                 $colnum = 1;
+                $col = '';
                 foreach ($columns as $key => $column) {
                     $col = '';
                     if ($colnum > $char) {
@@ -418,13 +419,13 @@ class Excel extends \yii\base\Widget
                 }
 
                 $activeSheet
-                    ->getStyleByColumnAndRow(1,1, $colnum - 1,$row)
+                    ->getStyle('A1:'.$col . $row)
                     ->applyFromArray($this->headerStyle);
                 if($this->freezeHeader){
                     $activeSheet->freezePaneByColumnAndRow(1,2);
                 }
                 if($this->autoFilter) {
-                    $activeSheet->setAutoFilterByColumnAndRow(1, 1, $colnum - 1, $row);
+                    $activeSheet->setAutoFilter('A1:'.$col . $row);
                 }
                 $hasHeader = true;
                 $row++;

--- a/Excel.php
+++ b/Excel.php
@@ -2,8 +2,10 @@
 
 namespace moonland\phpexcel;
 
+use arogachev\excel\helpers\PHPExcelHelper;
 use DateTime;
 use DateTimeZone;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -559,6 +561,12 @@ class Excel extends Widget
                                 ->setFormatCode($this->dateFormat);
                             break;
                         case 'text':
+                            if (is_string($column_value) && $column_value[0] === '0') {
+                                $activeSheet
+                                    ->getCell($col . $row)
+                                    ->setValueExplicit($column_value, DataType::TYPE_STRING);
+                                break;
+                            }
                             $activeSheet
                                 ->getStyle($col . $row)
                                 ->getNumberFormat()

--- a/Excel.php
+++ b/Excel.php
@@ -587,7 +587,7 @@ class Excel extends Widget
                                 ->setFormatCode($this->dateFormat);
                             break;
                         case 'date-time':
-                            if($date = DateTime::createFromFormat('Y-m-d H:i:s',$column_value)) {
+                            if($date = DateTime::createFromFormat('Y-m-d H:i:s',$column_value,new DateTimeZone('UTC'))) {
                                 $column_value = Date::PHPToExcel($date->getTimestamp());
                                 $activeSheet
                                     ->getStyle($col . $row)

--- a/Excel.php
+++ b/Excel.php
@@ -103,7 +103,9 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
  *                    'value' => function($model) {
  *                        return ExampleClass::removeText('example', $model->content);
  *                    },
- *                    'visible' => true
+ *                    'visible' => true,
+ *       			  'excelWidth' => 50,
+ *                    'excelWrap' => true
  *            ],
  *            'like_it:text:Reader like this content',
  *            'created_at:datetime',
@@ -412,7 +414,9 @@ class Excel extends \yii\base\Widget
                     }
                     $activeSheet->setCellValue($col . $row, $header);
 
-                    if (isset($column['attribute'])){
+                    if (isset($column['excelWidth'])) {
+                        $activeSheet->getColumnDimension($col)->setWidth($column['excelWidth']);
+                    }elseif (!isset($column['autoSize']) || $column['autoSize']){
                         $activeSheet->getColumnDimension($col)->setAutoSize(true);
                     }
                     $colnum ++;
@@ -474,6 +478,14 @@ class Excel extends \yii\base\Widget
                             ->setFormatCode(NumberFormat::FORMAT_DATE_DDMMYYYY);
                     }
                 }
+                if (isset($column['excelWrap'])) {
+                    $activeSheet
+                        ->getStyle($col . $row)
+                        ->getAlignment()
+                        ->setWrapText($column['excelWrap'])
+                    ;
+                }
+
                 $colnum++;
             }
             $row++;

--- a/Excel.php
+++ b/Excel.php
@@ -453,7 +453,12 @@ class Excel extends Widget
      * @param Worksheet|null $activeSheet
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    private function executeColumns(&$models, $columns = [], $headers = [],Worksheet &$activeSheet = null ): void
+    private function executeColumns(
+        &$models,
+        array $columns = [],
+        array $headers = [],
+        ?Worksheet &$activeSheet = null
+    ): void
     {
         if ($activeSheet === null) {
             $activeSheet = $this->activeSheet;
@@ -536,7 +541,7 @@ class Excel extends Widget
                         ->applyFromArray($column['headerStyle']);
                 }
                 if ($this->freezeHeader) {
-                    $activeSheet->freezePaneByColumnAndRow(1, $row + 1);
+                    $activeSheet->freezePane('A' . ($row + 1));
                 }
                 if ($this->autoFilter) {
                     $activeSheet->setAutoFilter('A' . $row . ':' . $col . $row);

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -135,7 +135,7 @@ class LoadDataInExcel
 
         $this
             ->sheet
-            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValue());
+            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValueForExcel());
 
         if ($cell->columnAutoSize) {
             $this

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -97,7 +97,7 @@ class LoadDataInExcel
                 $this->tn->x,
                 $this->tn->y,
                 $this->tn->x + $cell->colspan - 1,
-                $this->tn->y
+                $this->tn->y + $cell->rowspan - 1
             );
         }
         if ($cell->rowspan !== 1) {
@@ -105,7 +105,7 @@ class LoadDataInExcel
             $this->sheet->mergeCellsByColumnAndRow(
                 $this->tn->x,
                 $this->tn->y,
-                $this->tn->x,
+                $this->tn->x + $cell->colspan - 1,
                 $this->tn->y + $cell->rowspan - 1
             );
         }

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -45,7 +45,7 @@ class LoadDataInExcel
             'bold' => true
         ],
         'alignment' => [
-            'horizontal' => Alignment::HORIZONTAL_CENTER,
+            'horizontal' => Alignment::HORIZONTAL_CENTER
         ],
         'fill' => [
             'fillType' => Fill::FILL_SOLID,
@@ -113,7 +113,11 @@ class LoadDataInExcel
         $classStyle = [];
 
         if ($cell->tag === 'th') {
-            $classStyle[] = $this->thStyle;
+            $style = $this->thStyle;
+            if (!$cell->nowrap) {
+                $style['alignment']['wrapText'] = true;
+            }
+            $classStyle[] = $style;
         }
         if ($cell->numberDecimals !== false) {
             if ($cell->numberDecimals === 0) {

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -128,14 +128,14 @@ class LoadDataInExcel
                 ->setFormatCode($numberFormat);
             $classStyle[] = [
                 'alignment' => [
-                    'horizontal' => Alignment::HORIZONTAL_CENTER,
+                    'horizontal' => $cell->horizontalAlign?:Alignment::HORIZONTAL_CENTER,
                 ],
             ];
         }
 
         $this
             ->sheet
-            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValueForExcel());
+            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValueForExcel($this->tn->x, $this->tn->y));
 
         if ($cell->columnAutoSize) {
             $this
@@ -186,11 +186,9 @@ class LoadDataInExcel
         reset($row);
         /** @var TableTdCell $cell */
         foreach ($row as $cellKey => $cell) {
-            if ($cell === null) {
-                continue;
+            if ($cell !== null) {
+                $this->fillCell($cell);
             }
-            $this->fillCell($cell);
-
 
             if ($cellKey !== $lastKey) {
                 $this->tn->nextCell();

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -12,6 +12,8 @@ class LoadDataInExcel
     /** @var TableNavigator */
     public $tn;
 
+    public $colunWidth = [];
+
     public $styleTitle = [
         'font' => [
             'bold' => true,
@@ -45,7 +47,8 @@ class LoadDataInExcel
             'bold' => true
         ],
         'alignment' => [
-            'horizontal' => Alignment::HORIZONTAL_CENTER
+            'horizontal' => Alignment::HORIZONTAL_CENTER,
+            'vertical' => Alignment::VERTICAL_TOP
         ],
         'fill' => [
             'fillType' => Fill::FILL_SOLID,
@@ -139,15 +142,15 @@ class LoadDataInExcel
 
         $this
             ->sheet
-            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValueForExcel($this->tn->x, $this->tn->y));
+            ->setCellValueByColumnAndRow(
+                $this->tn->x,
+                $this->tn->y,
+                $cell->getValueForExcel($this->tn->x, $this->tn->y)
+            );
 
-        if ($cell->columnAutoSize) {
-            $this
-                ->sheet
-                ->getColumnDimensionByColumn($this->tn->y)
-                ->setAutoSize(true);
+        if ($cell->width) {
+            $this->colunWidth[$this->tn->x] = $cell->width;
         }
-
         if ($cell->class) {
             $cellClass = $cell->class;
             if (!is_array($cellClass)) {
@@ -170,10 +173,9 @@ class LoadDataInExcel
                     $this->tn->y,
                     $this->tn->x + $cell->colspan - 1,
                     $this->tn->y + $cell->rowspan - 1
-                    )
+                )
                 ->applyFromArray($classStyle);
         }
-
     }
 
     /**
@@ -193,11 +195,20 @@ class LoadDataInExcel
             if ($cell !== null) {
                 $this->fillCell($cell);
             }
-
             if ($cellKey !== $lastKey) {
                 $this->tn->nextCell();
             }
         }
     }
 
+    public function setColumnsWidths(): void
+    {
+        foreach ($this->colunWidth as $column => $size) {
+            $this
+                ->sheet
+                ->getColumnDimensionByColumn($column)
+                ->setAutoSize(false)
+                ->setWidth($size);
+        }
+    }
 }

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -119,7 +119,7 @@ class LoadDataInExcel
             if ($cell->numberDecimals === 0) {
                 $numberFormat = NumberFormat::FORMAT_NUMBER;
             } else {
-                $numberFormat = '0.' . str_repeat('0', $cell->numberDecimals);
+                $numberFormat = '#,##0.' . str_repeat('0', $cell->numberDecimals);
             }
             $this
                 ->sheet

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -1,6 +1,7 @@
 <?php
 namespace moonland\phpexcel;
 
+use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
@@ -52,6 +53,10 @@ class LoadDataInExcel
         ],
     ];
 
+    /**
+     * @param string $tableTitle
+     * @throws Exception
+     */
     public function setTableTitle(string $tableTitle): void
     {
         $this
@@ -79,17 +84,21 @@ class LoadDataInExcel
 
     /**
      * @param TableTdCell $cell
-     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws Exception
      */
     public function fillCell($cell): void
     {
+        if (!$cell) {
+            return;
+        }
         if ($cell->colspan !== 1) {
             $this->tn->setColspan($cell->colspan);
             $this->sheet->mergeCellsByColumnAndRow(
                 $this->tn->x,
                 $this->tn->y,
                 $this->tn->x + $cell->colspan - 1,
-                $this->tn->y);
+                $this->tn->y
+            );
         }
         if ($cell->rowspan !== 1) {
             $this->tn->setRowspan($cell->rowspan);
@@ -160,7 +169,7 @@ class LoadDataInExcel
 
     /**
      * @param TableTdCell[] $row
-     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws Exception
      */
     public function fillRow(array &$row): void
     {
@@ -172,8 +181,7 @@ class LoadDataInExcel
         reset($row);
         /** @var TableTdCell $cell */
         foreach ($row as $cellKey => $cell) {
-
-            if($cell) {
+            if ($cell) {
                 $this->fillCell($cell);
             }
 

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -161,7 +161,12 @@ class LoadDataInExcel
             $classStyle = array_merge(...$classStyle);
             $this
                 ->sheet
-                ->getStyleByColumnAndRow($this->tn->x, $this->tn->y)
+                ->getStyleByColumnAndRow(
+                    $this->tn->x,
+                    $this->tn->y,
+                    $this->tn->x + $cell->colspan - 1,
+                    $this->tn->y + $cell->rowspan - 1
+                    )
                 ->applyFromArray($classStyle);
         }
 

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -1,0 +1,186 @@
+<?php
+namespace moonland\phpexcel;
+
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class LoadDataInExcel
+{
+    /** @var TableNavigator */
+    public $tn;
+
+    public $styleTitle = [
+        'font' => [
+            'bold' => true,
+            'size' => 14
+        ],
+        'alignment' => [
+            'horizontal' => Alignment::HORIZONTAL_CENTER,
+        ],
+    ];
+
+    public $classStyle = [];
+
+    /**
+     * LoadDataInExcel constructor.
+     * @param Worksheet $sheet
+     * @param int $x
+     * @param int $y
+     */
+    public function __construct(Worksheet $sheet, int $x = 1, int $y = 1)
+    {
+        $this->tn = new TableNavigator($x, $y);
+        $this->sheet = $sheet;
+    }
+
+    /** @var Worksheet */
+    public $sheet;
+
+
+    public $thStyle = [
+        'font' => [
+            'bold' => true
+        ],
+        'alignment' => [
+            'horizontal' => Alignment::HORIZONTAL_CENTER,
+        ],
+        'fill' => [
+            'fillType' => Fill::FILL_SOLID,
+            'color' => ['rgb' => 'EEEEEE']
+        ],
+    ];
+
+    public function setTableTitle(string $tableTitle): void
+    {
+        $this
+            ->sheet
+            ->mergeCellsByColumnAndRow(
+                $this->tn->minX,
+                $this->tn->minY,
+                $this->tn->maxX,
+                $this->tn->minY
+            );
+
+        $this
+            ->sheet
+            ->setCellValueByColumnAndRow(
+                $this->tn->minX,
+                $this->tn->minY,
+                $tableTitle
+            );
+
+        $this
+            ->sheet
+            ->getStyleByColumnAndRow($this->tn->minX, $this->tn->minY)
+            ->applyFromArray($this->styleTitle);
+    }
+
+    /**
+     * @param TableTdCell $cell
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     */
+    public function fillCell($cell): void
+    {
+        if ($cell->colspan !== 1) {
+            $this->tn->setColspan($cell->colspan);
+            $this->sheet->mergeCellsByColumnAndRow(
+                $this->tn->x,
+                $this->tn->y,
+                $this->tn->x + $cell->colspan - 1,
+                $this->tn->y);
+        }
+        if ($cell->rowspan !== 1) {
+            $this->tn->setRowspan($cell->rowspan);
+            $this->sheet->mergeCellsByColumnAndRow(
+                $this->tn->x,
+                $this->tn->y,
+                $this->tn->x,
+                $this->tn->y + $cell->rowspan - 1
+            );
+        }
+
+        $classStyle = [];
+
+        if ($cell->tag === 'th') {
+            $classStyle[] = $this->thStyle;
+        }
+        if ($cell->numberDecimals !== false) {
+            if ($cell->numberDecimals === 0) {
+                $numberFormat = NumberFormat::FORMAT_NUMBER;
+            } else {
+                $numberFormat = '0.' . str_repeat('0', $cell->numberDecimals);
+            }
+            $this
+                ->sheet
+                ->getStyleByColumnAndRow($this->tn->x, $this->tn->y)
+                ->getNumberFormat()
+                ->setFormatCode($numberFormat);
+            $classStyle[] = [
+                'alignment' => [
+                    'horizontal' => Alignment::HORIZONTAL_CENTER,
+                ],
+            ];
+        }
+
+        $this
+            ->sheet
+            ->setCellValueByColumnAndRow($this->tn->x, $this->tn->y, $cell->getValue());
+
+        if ($cell->columnAutoSize) {
+            $this
+                ->sheet
+                ->getColumnDimensionByColumn($this->tn->y)
+                ->setAutoSize(true);
+        }
+
+        if ($cell->class) {
+            $cellClass = $cell->class;
+            if (!is_array($cellClass)) {
+                $cellClass = [$cellClass];
+            }
+            foreach ($cellClass as $className) {
+                if (!isset($this->classStyle[$className])) {
+                    continue;
+                }
+                $classStyle[] = $this->classStyle[$className];
+            }
+        }
+
+        if ($classStyle) {
+            $classStyle = array_merge(...$classStyle);
+            $this
+                ->sheet
+                ->getStyleByColumnAndRow($this->tn->x, $this->tn->y)
+                ->applyFromArray($classStyle);
+        }
+
+    }
+
+    /**
+     * @param TableTdCell[] $row
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     */
+    public function fillRow(array &$row): void
+    {
+        /**
+         * get last cell key
+         */
+        end($row);
+        $lastKey = key($row);
+        reset($row);
+        /** @var TableTdCell $cell */
+        foreach ($row as $cellKey => $cell) {
+
+            if($cell) {
+                $this->fillCell($cell);
+            }
+
+            if ($cellKey !== $lastKey) {
+                $this->tn->nextCell();
+            }
+        }
+    }
+
+}

--- a/LoadDataInExcel.php
+++ b/LoadDataInExcel.php
@@ -181,9 +181,11 @@ class LoadDataInExcel
         reset($row);
         /** @var TableTdCell $cell */
         foreach ($row as $cellKey => $cell) {
-            if ($cell) {
-                $this->fillCell($cell);
+            if ($cell === null) {
+                continue;
             }
+            $this->fillCell($cell);
+
 
             if ($cellKey !== $lastKey) {
                 $this->tn->nextCell();

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 Yii2 PHP Excel
 ==============
 
-[![Latest Stable Version](https://poser.pugx.org/moonlandsoft/yii2-phpexcel/v/stable)](https://packagist.org/packages/moonlandsoft/yii2-phpexcel) 
-[![Total Downloads](https://poser.pugx.org/moonlandsoft/yii2-phpexcel/downloads)](https://packagist.org/packages/moonlandsoft/yii2-phpexcel) 
-[![Latest Unstable Version](https://poser.pugx.org/moonlandsoft/yii2-phpexcel/v/unstable)](https://packagist.org/packages/moonlandsoft/yii2-phpexcel) 
 [![License](https://poser.pugx.org/moonlandsoft/yii2-phpexcel/license)](https://packagist.org/packages/moonlandsoft/yii2-phpexcel)
 
 Exporting PHP to Excel or Importing Excel to PHP.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ string `$getOnlySheet` is a sheet name to getting the data. This is only get the
 
 array|Formatter `$formatter` the formatter used to format model attribute values into displayable texts. This can be either an instance of [[Formatter]] or an configuration array for creating the [[Formatter]] instance. If this property is not set, the "formatter" application component will be used.
 
+boolean `$freezeHeader` set freeze header
+
+boolean `$autoFilter` set auto filter to header
+
+array `$headerStyle` header style  in array format for PhpSpreadsheet 
+
 Installation
 ------------
 
@@ -145,10 +151,13 @@ Columns in string mode valid layout are 'attribute:format:header:footer(TODO)'.
       		[
       				'attribute' => 'content',
       				'header' => 'Content Post',
-      				'format' => 'text',
+      				'format' => 'text', // ['decimal',3]
       				'value' => function($model) {
       					return ExampleClass::removeText('example', $model->content);
       				},
+      				'visible' => true,
+      				'autosize' => true,
+      				'format' = 
       		],
       		'like_it:text:Reader like this content',
       		'created_at:datetime',

--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ Columns in string mode valid layout are 'attribute:format:header:footer(TODO)'.
       		[
       				'attribute' => 'content',
       				'header' => 'Content Post',
-      				'format' => 'text', // ['decimal',3]
+      				'format' => 'text', // ['decimal',3], 'date'
       				'value' => function($model) {
       					return ExampleClass::removeText('example', $model->content);
       				},
       				'visible' => true,
-      				'autosize' => true,
-      				'format' = 
+      				'autoSize' => true,
+      				'excelWidth' => 50,
+      				'excelWrap' => true
+      				
       		],
       		'like_it:text:Reader like this content',
       		'created_at:datetime',

--- a/README.md
+++ b/README.md
@@ -244,6 +244,46 @@ Array([file1] => Array([Sheet1] => Array([0] => Array([name] => Anam, [email] =>
 
 ```
 
+With title
+----------
+
+```php
+$labels = [
+    [
+        'label' => 'Pārskats',
+        'class' => 'title'
+    ],
+];
+
+
+$title = new TableTdCell('title');
+$title->class = 'title';
+$title->colspan = 11;
+
+$titleClassStyle = [
+    'title' => [
+        'font' => [
+            'size' => 16,
+        ],
+        'alignment' => [
+            'horizontal' => 'center',
+        ],
+    ],
+];
+
+Excel::widget([
+    'models' => $dataProvider->getModels(),
+    'mode' => 'export', //default value as 'export'
+    'fileName' => 'month_total_' . date('ymdHi'),
+    'columns' => $columns,
+    //'' => 'LSEZ SIA "Ekers Stividors LP", BMZ apl.  Nr. 40',
+    //'headers' => $headers
+    'titleRows' => [[$title]],
+    'loadDataInExcelStyle' => $titleClassStyle
+]);
+
+```
+
 TODO
 ----
 - Adding footer params for columns in exporting data.

--- a/TableDecimalCell.php
+++ b/TableDecimalCell.php
@@ -3,8 +3,9 @@
 namespace moonland\phpexcel;
 
 use Closure;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
-class TableThCell extends TableTdCell {
+class TableDecimalCell extends TableTdCell {
 
     /**
      * TableThCell constructor.
@@ -16,7 +17,8 @@ class TableThCell extends TableTdCell {
     public function __construct($value = '', array $class = [], int $colspan = 1, int $rowspan = 1)
     {
         parent::__construct($value, $class, $colspan, $rowspan);
-        $this->tag = 'th';
+        $this->numberDecimals = 2;
+        $this->horizontalAlign = Alignment::HORIZONTAL_RIGHT;
     }
 
 

--- a/TableNavigator.php
+++ b/TableNavigator.php
@@ -1,0 +1,58 @@
+<?php
+namespace moonland\phpexcel;
+
+class TableNavigator
+{
+    public $x;
+    public $y;
+
+    public $minX;
+    public $minY;
+    public $maxX;
+    public $maxY;
+
+    public $usedCells = [];
+
+    public function __construct(int $x = 1, int $y = 1)
+    {
+        $this->x = $this->y = 1;
+        $this->minX = $this->maxX = $x;
+        $this->minY = $this->maxY = $y;
+    }
+
+    public function nextCell(): void
+    {
+        do {
+            $this->x++;
+        } while (isset($this->usedCells[$this->x][$this->y]));
+        $this->maxX = max($this->x, $this->maxX);
+    }
+
+    public function newLine(): void
+    {
+        $this->x = $this->minX - 1;
+        $this->y++;
+        $this->nextCell();
+        $this->maxY = max($this->y, $this->maxY);
+    }
+
+    public function setColspan(int $columns): void
+    {
+        $i = 1;
+        while ($i < $columns) {
+            $this->usedCells[$this->x + $i][$this->y] = [$this->x, $this->y];
+            $i++;
+        }
+    }
+
+    public function setRowspan(int $rows): void
+    {
+        $i = 1;
+        while ($i < $rows) {
+            $this->usedCells[$this->x][$this->y + $i] = [$this->x, $this->y];
+            $i++;
+        }
+    }
+
+
+}

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -55,6 +55,14 @@ class TableTdCell
         return $this->params[$name] ?? false;
     }
 
+    public function getValueForExcel(): string
+    {
+        if ($this->numberDecimals !== false) {
+            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
+        }
+        return $this->value;
+    }
+
     public function getValue(): string
     {
         if(count($this->dropDownItems) === 1){

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -20,6 +20,8 @@ class TableTdCell
     public $numberDecimals = false;
     public $columnAutoSize = true;
     public $horizontalAlign;
+    public $width;
+    public $grupa;
 
     /** @var array label list with urls for ThButtonDropDown*/
     public $dropDownItems = [];
@@ -116,9 +118,6 @@ class TableTdCell
             $options['data-container'] = 'body';
             $options['data-original-title'] = '';
         }
-
         return Html::tag($this->tag, $this->getValue(), $options);
-
     }
-
 }

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -59,13 +59,17 @@ class TableTdCell
 
     public function getValueForExcel(int $x, int $y): string
     {
-        if(is_string($this->value)) {
-            if ($this->numberDecimals !== false) {
-                return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
-            }
-            return $this->value;
+
+        if($this->value instanceof Closure) {
+            return call_user_func($this->value, $x, $y);
         }
-        return call_user_func($this->value, $x, $y);
+
+        if ($this->numberDecimals !== false) {
+            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
+        }
+        return $this->value;
+
+
     }
 
     public function getValue(): string

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -3,6 +3,7 @@
 namespace moonland\phpexcel;
 
 
+use Closure;
 use eaBlankonThema\widget\ThButtonDropDown;
 use yii\helpers\Html;
 
@@ -18,6 +19,7 @@ class TableTdCell
     public $urlOptions = [];
     public $numberDecimals = false;
     public $columnAutoSize = true;
+    public $horizontalAlign;
 
     /** @var array label list with urls for ThButtonDropDown*/
     public $dropDownItems = [];
@@ -31,12 +33,12 @@ class TableTdCell
 
     /**
      * TableCell constructor.
-     * @param string $value *
+     * @param string|Closure $value *
      * @param array $class
      * @param $colspan
      * @param $rowspan
      */
-    public function __construct(string $value = '', array $class = [], $colspan = 1, $rowspan = 1)
+    public function __construct($value = '', array $class = [], $colspan = 1, $rowspan = 1)
     {
         $this->value = $value;
         $this->colspan = $colspan;
@@ -55,12 +57,15 @@ class TableTdCell
         return $this->params[$name] ?? false;
     }
 
-    public function getValueForExcel(): string
+    public function getValueForExcel(int $x, int $y): string
     {
-        if ($this->numberDecimals !== false) {
-            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
+        if(is_string($this->value)) {
+            if ($this->numberDecimals !== false) {
+                return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
+            }
+            return $this->value;
         }
-        return $this->value;
+        return call_user_func($this->value, $x, $y);
     }
 
     public function getValue(): string

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -3,6 +3,8 @@
 namespace moonland\phpexcel;
 
 
+use yii\helpers\Html;
+
 class TableTdCell
 {
     public $tag = 'td';
@@ -16,19 +18,21 @@ class TableTdCell
     public $numberDecimals = false;
     public $columnAutoSize = true;
 
+    /** @var string */
+    public $tooltipText;
+
     public $style = [];
 
     public $params;
 
     /**
      * TableCell constructor.
-     * @param string $value*
+     * @param string $value *
      * @param array $class
      * @param $colspan
      * @param $rowspan
-
      */
-    public function __construct(string $value = '', array $class =[], $colspan = 1,  $rowspan = 1)
+    public function __construct(string $value = '', array $class = [], $colspan = 1, $rowspan = 1)
     {
         $this->value = $value;
         $this->colspan = $colspan;
@@ -36,23 +40,55 @@ class TableTdCell
         $this->class = $class;
     }
 
-    public function setParam(string $name, $value)
+    public function setParam(string $name, $value): void
     {
         $this->params[$name] = $value;
     }
 
 
-    public function getParam(string $name)
+    public function getParam(string $name): bool
     {
-        return $this->params[$name]??false;
+        return $this->params[$name] ?? false;
     }
 
-    public function getValue()
+    public function getValue(): string
     {
-        if($this->numberDecimals !== false) {
-            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals,'.','');
+        if ($this->numberDecimals !== false) {
+            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
         }
         return $this->value;
     }
+
+    public function getHtml(): string
+    {
+        $options = [];
+        if ($this->colspan !== 1) {
+            $options['colspan'] = $this->colspan;
+        }
+        if ($this->rowspan !== 1) {
+            $options['rowspan'] = $this->rowspan;
+        }
+        if ($this->class) {
+            $options['class'] = $this->class;
+        }
+        if ($this->nowrap) {
+            $options['class'] = array_merge($this->class, ['text-nowrap']);
+        }
+
+        if ($this->tooltipText) {
+            $options['data-title'] = $this->tooltipText;
+            $options['data-placement'] = 'top';
+            $options['data-toggle'] = 'tooltip';
+            $options['data-container'] = 'body';
+            $options['data-original-title'] = '';
+        }
+
+        if(!$this->url) {
+            return Html::tag($this->tag, $this->getValue(), $options);
+        }
+
+        return Html::tag($this->tag, Html::a($this->getValue(), $this->url, $this->urlOptions), $options);
+    }
+
 
 }

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace moonland\phpexcel;
+
+
+class TableTdCell
+{
+    public $tag = 'td';
+    private $value;
+    public $colspan;
+    public $rowspan;
+    public $class = [];
+    public $nowrap = false;
+    public $url = [];
+    public $urlOptions = [];
+    public $numberDecimals = false;
+    public $columnAutoSize = true;
+
+    public $style = [];
+
+    public $params;
+
+    /**
+     * TableCell constructor.
+     * @param string $value*
+     * @param array $class
+     * @param $colspan
+     * @param $rowspan
+
+     */
+    public function __construct(string $value = '', array $class =[], $colspan = 1,  $rowspan = 1)
+    {
+        $this->value = $value;
+        $this->colspan = $colspan;
+        $this->rowspan = $rowspan;
+        $this->class = $class;
+    }
+
+    public function setParam(string $name, $value)
+    {
+        $this->params[$name] = $value;
+    }
+
+
+    public function getParam(string $name)
+    {
+        return $this->params[$name]??false;
+    }
+
+    public function getValue()
+    {
+        if($this->numberDecimals !== false) {
+            return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals,'.','');
+        }
+        return $this->value;
+    }
+
+}

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -3,6 +3,7 @@
 namespace moonland\phpexcel;
 
 
+use eaBlankonThema\widget\ThButtonDropDown;
 use yii\helpers\Html;
 
 class TableTdCell
@@ -13,10 +14,13 @@ class TableTdCell
     public $rowspan;
     public $class = [];
     public $nowrap = false;
-    public $url = [];
+    public $url;
     public $urlOptions = [];
     public $numberDecimals = false;
     public $columnAutoSize = true;
+
+    /** @var array label list with urls for ThButtonDropDown*/
+    public $dropDownItems = [];
 
     /** @var string */
     public $tooltipText;
@@ -53,6 +57,19 @@ class TableTdCell
 
     public function getValue(): string
     {
+        if(count($this->dropDownItems) === 1){
+            $this->url = array_values($this->dropDownItems)[0]['url'];
+            $this->dropDownItems = [];
+        }
+        if($this->dropDownItems){
+            return ThButtonDropDown::widget([
+                'label' => $this->value,
+                'items' => $this->dropDownItems
+            ]);
+        }
+        if($this->url) {
+            return Html::a($this->value, $this->url, $this->urlOptions);
+        }
         if ($this->numberDecimals !== false) {
             return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
         }
@@ -83,12 +100,8 @@ class TableTdCell
             $options['data-original-title'] = '';
         }
 
-        if(!$this->url) {
-            return Html::tag($this->tag, $this->getValue(), $options);
-        }
+        return Html::tag($this->tag, $this->getValue(), $options);
 
-        return Html::tag($this->tag, Html::a($this->getValue(), $this->url, $this->urlOptions), $options);
     }
-
 
 }

--- a/TableTdCell.php
+++ b/TableTdCell.php
@@ -89,7 +89,7 @@ class TableTdCell
         if($this->url) {
             return Html::a($this->value, $this->url, $this->urlOptions);
         }
-        if ($this->numberDecimals !== false) {
+        if ($this->numberDecimals !== false && $this->value !== '') {
             return number_format(round($this->value, $this->numberDecimals), $this->numberDecimals, '.', '');
         }
         return $this->value;

--- a/TableThCell.php
+++ b/TableThCell.php
@@ -6,6 +6,7 @@ use Closure;
 
 class TableThCell extends TableTdCell {
 
+    public $grupa;
     /**
      * TableThCell constructor.
      * @param string|Closure $value

--- a/TableThCell.php
+++ b/TableThCell.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace moonland\phpexcel;
+
+class TableThCell extends TableTdCell {
+
+    public function __construct(string $value = '', array $class = [], int $colspan = 1, int $rowspan = 1)
+    {
+        parent::__construct($value, $class, $colspan, $rowspan);
+        $this->tag = 'th';
+    }
+
+
+}

--- a/TableThCell.php
+++ b/TableThCell.php
@@ -6,7 +6,7 @@ use Closure;
 
 class TableThCell extends TableTdCell {
 
-    public $grupa;
+
     /**
      * TableThCell constructor.
      * @param string|Closure $value

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "phpoffice/phpexcel": "*"
+        "phpoffice/phpspreadsheet": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "phpoffice/phpspreadsheet": "dev-master"
+        "phpoffice/phpspreadsheet": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently getFileName() method always ads ".xls" extension if $fileName does not have an extension, which is wrong because extension depends on the $format member. And the default format is 'Excel2007'...